### PR TITLE
Import v0 specs/docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
-# Keep this repository intentionally empty for now.
-.DS_Store
+# Node / TS
+node_modules/
+dist/
+.turbo/
+.cache/
 
+# Env / secrets
+.env
+.env.*
+
+# Runs / caches (generated)
+**/runs/
+**/cache/
+
+# OS / editor
+.DS_Store
+.idea/
+.vscode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to mar21
+
+`mar21` is currently **docs-first**: the goal is to stabilize the operating model and interfaces before shipping a lot of code.
+
+## What we accept
+- Clarifications, fixes, and expansions to the docs:
+  - `docs/MANIFESTO.md`
+  - `docs/ARCHITECTURE.md`
+  - `docs/SPECS.md`
+  - `docs/WORKFLOWS.md`
+  - `docs/CONNECTORS.md`
+  - `docs/SECURITY.md`
+  - `docs/ROADMAP.md`
+- Proposals for new skills/connectors as **specs** (manifests + contracts), even if code isn’t implemented yet.
+
+## How to contribute (docs/specs)
+1) Open an issue describing the change and why it matters.
+2) Prefer small PRs that:
+   - keep interfaces stable (Context, Skill I/O, ChangeSet, Run artifacts),
+   - add concrete examples,
+   - document safety/risk.
+3) If you propose a breaking change to an interface:
+   - explain migration,
+   - justify why the old interface can’t work,
+   - propose a version bump (`mar21/v2`, `changeset-v2`, etc.).
+
+## Non-negotiables
+- Supervised-by-default (autonomy must be explicitly allowlisted)
+- No secrets in repo
+- GDPR-first defaults (redaction + minimization)
+- All workflows are run-based and emit Plan + Report + ChangeSet
+
+## Style
+- Be concrete: show example YAML/JSON snippets.
+- Prefer naming conventions over prose.
+- Keep language direct and operator-friendly.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# mar21
+**AI-native Marketing Operating System** — an open-source boilerplate for *one-person marketing* from GTM strategy to operational execution and reporting.
+
+`mar21` is not “a few automations”. It is a **repository convention + skill system + connector interfaces + CLI agent surface** that lets an operator run marketing as an **auditable engine**:
+
+- **Context-first**: persistent marketing context lives in versioned YAML (company, model, KPIs, constraints, risk).
+- **Run-based**: work happens in runs that always emit **Plan + Report + ChangeSet**.
+- **Supervised-by-default**: the agent proposes changes; you approve (or opt-in to safe autopilot).
+- **Connector-driven**: first-class interfaces to typical marketing tools (v1: GSC, GA4, Meta Ads, HubSpot, Shopify, WordPress, Slack, Klaviyo).
+- **Own your AI**: keep competence, memory, and decision logic in *your* repo; still leverage platform-native AI where helpful.
+- **Moving target**: this repo is designed to evolve with the space—one step at a time, with stable interfaces.
+
+## What’s in this repo (today)
+Docs are the product for v0: the manifesto + the decision-complete interfaces you’ll build against.
+
+- `docs/MANIFESTO.md` — beliefs, principles, anti-patterns
+- `docs/ARCHITECTURE.md` — system decomposition + repo layout (TypeScript/Node monorepo)
+- `docs/SPECS.md` — canonical file formats and contracts (context, skills, connectors, ChangeSet YAML, runs, memory)
+- `docs/WORKFLOWS.md` — operator playbook (8 workflows + daily/weekly/monthly loops)
+- `docs/CONNECTORS.md` — per-tool integration boundaries and capabilities (v1 tools)
+- `docs/connectors/README.md` — exhaustive per-tool capability catalogs (v1)
+- `docs/SECURITY.md` — secrets, approvals, redaction, retention (GDPR-first)
+- `docs/ROADMAP.md` — how `mar21` evolves (interfaces stable, implementations iterate)
+- `docs/GLOSSARY.md` — shared vocabulary (runs, skills, ChangeSets, capabilities)
+- `docs/EXAMPLES.md` — concrete example artifacts (context, run, ChangeSet)
+- `docs/CLI.md` — CLI UX spec (commands, prompts, exit codes)
+- `docs/DATA_MODEL.md` — canonical metrics, joins, attribution disclaimers
+- `docs/EVALS.md` — quality gates and golden-run fixtures
+- `docs/DEV.md` — implementation guide (Node 20 + pnpm, `_cfg/` overrides)
+- `docs/VERSIONING.md` — compatibility policy for the stable surface
+- `docs/SCHEMAS.md` — schema strategy + mapping
+- `docs/GOVERNANCE.md` — maintainer model + security reporting
+- `docs/STRUCTURE_PATTERNS.md` — standardized repo patterns (`_cfg/`, manifests, runs)
+- `docs/BEST_PRACTICES.md` — evidence-based marketing principles encoded into the OS
+- `docs/BACKLOG.md` — concept gaps turned into concrete spec backlog
+- `docs/CREATIVE.md` — creative briefs, asset manifests, fatigue, distinctive assets
+- `docs/DISTRIBUTION.md` — owned/earned/paid distribution planning and repurposing
+- `docs/TASKS.md` — task system (`todos.yaml` + `mar21.todo.*` ops) for non-API work
+- `CONTRIBUTING.md` — contribution guidelines (docs-first, interface stability)
+
+## Mental model
+1) **You** declare what “good marketing” means (KPIs, constraints, budget, voice, risk tolerance).
+2) **Connectors** fetch reality (GSC/GA4/Ads/CRM/Commerce/CMS).
+3) **Skills** turn reality into decisions (analysis → hypotheses → actions).
+4) **Runs** persist everything (inputs, outputs, logs, approvals).
+5) **ChangeSets** encode concrete actions (tool-scoped operations) that can be reviewed and applied.
+
+## Proposed CLI surface (spec)
+This repo specifies an opinionated CLI, even before code exists:
+
+```bash
+mar21 init --workspace acme
+mar21 plan gtm --workspace acme
+
+mar21 analyze week --workspace acme
+mar21 report weekly --workspace acme
+
+mar21 run daily --workspace acme
+mar21 run weekly --workspace acme
+mar21 autopilot start --profile daily --workspace acme
+```
+
+## License
+Apache-2.0 — see `LICENSE`.
+
+## Contributing
+See `CONTRIBUTING.md`.
+
+## Next
+Start with the docs:
+- Read `docs/MANIFESTO.md`
+- Then `docs/ARCHITECTURE.md`
+- Then build to `docs/SPECS.md`
+- Operate via `docs/WORKFLOWS.md`
+- Deep-dive integrations in `docs/CONNECTORS.md`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,109 @@
+# mar21 Architecture
+
+This document specifies the system decomposition and the *intended* repository layout for a TypeScript/Node monorepo.
+
+`mar21` is **Codex-native + portable**:
+- Codex can run skills and automations effectively.
+- Portability is achieved by keeping the *stable surface* as file formats + interfaces (Context, Skill I/O, ChangeSet, Run Artifacts).
+
+## High-level components
+1) **CLI (`mar21`)**
+   - Owns user interaction (init wizard, run selection, interactive approvals)
+   - Produces run folders and artifacts
+
+2) **Core Orchestrator**
+   - Loads marketing context + memory
+   - Resolves which skills to run for a goal
+   - Coordinates connectors and writes ChangeSets
+
+3) **Skills (code-first, typed I/O)**
+   - Deterministic “units of marketing work”
+   - May use LLMs internally, but always expose typed inputs/outputs
+
+4) **Connectors**
+   - Auth + API calls for external tools
+   - Declare capabilities and risk (read-only vs write ops)
+   - Support dry-run and rate limiting
+
+5) **Run Artifacts + Memory**
+   - `runs/` is the audit trail (inputs, outputs, logs, approvals, changeset)
+   - `memory/` is the compounding knowledge base (learnings, winners/losers, exclusions)
+
+## Data flow (run-based)
+```mermaid
+flowchart TD
+  U["Operator"] --> CLI["mar21 CLI"]
+  CLI --> CTX["Marketing Context (YAML)"]
+  CLI --> MEM["Marketing Memory (files)"]
+  CLI --> ORCH["Orchestrator"]
+  ORCH --> CONN["Connectors (GSC/GA4/Meta/HubSpot/Shopify/WP/Slack/Klaviyo)"]
+  ORCH --> SK["Skills (typed I/O)"]
+  CONN --> SK
+  SK --> ORCH
+  ORCH --> ART["Run Artifacts: Plan + Report + ChangeSet + Logs"]
+  ART --> U
+  ORCH -->|optional| APPLY["Apply ChangeSet (supervised approvals)"]
+```
+
+## Proposed monorepo layout (TypeScript/Node)
+This is the opinionated layout `mar21` documentation assumes:
+
+```
+mar21/
+  docs/
+  packs/                  # optional: core + expansion packs (skills/workflows/templates)
+  dist/                   # optional: exported bundles for distribution
+  skills/                 # portable, tool-agnostic skill definitions
+  workspaces/
+    <workspace>/
+      marketing-context.yaml
+      memory/
+      runs/
+      secrets/
+  packages/
+    core/                 # orchestrator, run manager, artifact writers
+    cli/                  # mar21 binary
+    connectors/           # tool connectors
+      gsc/
+      ga4/
+      meta-ads/
+      hubspot/
+      shopify/
+      wordpress/
+      slack/
+      klaviyo/
+    adapters/
+      llm/                # provider-agnostic LLM interface + OpenAI adapter first
+      codex/              # Codex-friendly adapters (optional)
+  schemas/                # JSON Schemas for YAML/JSON artifacts (optional but recommended)
+  examples/               # Example instances validated by schemas
+```
+
+## Scheduling / autopilot stance (built-in loop runner)
+`mar21` assumes a **built-in loop runner** conceptually (even if users later run it under cron/CI):
+- `mar21 run daily|weekly|monthly` executes a named loop once and produces artifacts.
+- `mar21 autopilot start --profile daily` runs continuously, wakes on schedule, and emits one run per loop execution.
+- Autopilot is still **supervised-by-default** unless a workspace explicitly allowlists operations.
+
+Profiles are workspace-owned configuration (recommended):
+- `workspaces/<workspace>/profiles/daily.yaml`
+- `workspaces/<workspace>/profiles/weekly.yaml`
+- `workspaces/<workspace>/profiles/monthly.yaml`
+
+## Portability story
+Portability is achieved by making these artifacts and interfaces the stable surface:
+- `marketing-context.yaml`
+- `skills/*/skill.yaml` (typed input/output contract)
+- `changeset.yaml` (typed ops)
+- `runs/<id>/**` (logs + artifacts)
+
+Any agent runtime (Codex, a custom runner, another orchestrator) can implement:
+- “load context”
+- “execute skills”
+- “produce Plan/Report/ChangeSet”
+- “apply ChangeSet with approvals”
+
+See also:
+- `docs/CLI.md` (CLI contract)
+- `docs/SCHEMAS.md` + `schemas/` (validation contract)
+- `docs/connectors/README.md` (capability catalogs)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,179 @@
+# mar21 Backlog (Concept Gaps → Docs/Specs to Add)
+
+This backlog turns “end-to-end marketing value creation” gaps into concrete doc/spec work.
+
+Each item is: **Gap → Spec to add → Where it lives → Acceptance criteria**.
+
+## 1) Activation-to-revenue closure loop (truth pipeline)
+**Gap**: we have joins + disclaimers, but not a canonical cross-tool “truth pipeline” for revenue impact across long cycles (and refunds/offline).
+
+**Spec to add**
+- Canonical object map: `ad/campaign` → `session` → `lead` → `opportunity` → `revenue` (+ `refunds`/`churn`)
+- Explicit “source of truth per node” policy (GA4 vs Shopify vs HubSpot)
+- Offline conversion/backfill approach (even if v1 is “manual import”)
+
+**Where**
+- Add `docs/REVENUE_LOOP.md`
+- Extend `docs/DATA_MODEL.md` with a “truth pipeline” section
+- Add context fields in `docs/SPECS.md` (`measurement.truthPolicy`)
+
+**Acceptance criteria**
+- Weekly report can state: “pipeline moved because X” with an explicit join path and confidence.
+- “Unattributed share” is quantified per node (sessions, leads, revenue).
+
+## 2) Experimentation OS (hypotheses → tests → learnings)
+**Gap**: workflows mention tests, but there is no standard hypothesis registry, experiment design, guardrails, or stopping rules.
+
+**Spec to add**
+- `hypotheses.yaml` registry (id, claim, evidence refs, KPI node targeted, priority score)
+- `experiments.yaml` (design, variants, allocation, duration, stop criteria, guardrails)
+- Memory promotion rules (candidate → reviewed → accepted)
+
+**Where**
+- Add `docs/EXPERIMENTS.md`
+- Add schema files in `schemas/` for hypothesis/experiment registries
+- Add memory promotion section in `docs/SPECS.md`
+
+**Acceptance criteria**
+- Every plan references hypothesis ids; every report closes the loop with outcomes.
+
+## 3) Distribution system (beyond creation)
+**Gap**: content creation exists, but distribution (repurposing, syndication, PR/community/partner channels) isn’t specified as runs and artifacts.
+
+**Spec to add**
+- Distribution plan template + channel calendar
+- Repurposing rules (one idea → N assets → N channels)
+- Measurement mapping per distribution channel
+
+**Where**
+- Add `docs/DISTRIBUTION.md`
+- Extend `docs/WORKFLOWS.md` with `distribution_weekly` workflowId
+
+**Acceptance criteria**
+- A weekly loop produces a distribution calendar + measurable goals per channel.
+
+## 4) Creative production pipeline (assets, naming, fatigue)
+**Gap**: principles mention creativity/distinctive assets, but we don’t specify asset lifecycle and creative ops.
+
+**Spec to add**
+- Asset manifest (id, format, message, distinctive assets used, legal notes)
+- Creative test matrix spec (angles × formats × audiences)
+- Fatigue signals + refresh policy
+
+**Where**
+- Add `docs/CREATIVE.md`
+- Extend `docs/BEST_PRACTICES.md` with concrete “creative system” checklists
+- Add schemas for creative manifests
+
+**Acceptance criteria**
+- Ads workflows output a creative matrix and can attribute performance to asset ids.
+
+### Status
+Initial v1 spec added:
+- `docs/CREATIVE.md`
+- `docs/DISTRIBUTION.md`
+
+## 5) Technical SEO beyond GSC
+**Gap**: without crawl/site audit/log analysis interfaces, “technical excellence” remains mostly aspirational.
+
+**Spec to add**
+- A site audit connector contract (read-only) and evidence artifact shapes
+- Technical SEO workflowId (crawlability/indexability/CWV/structured data)
+
+**Where**
+- Add `docs/SEO_TECHNICAL.md`
+- Add a connector catalog stub under `docs/connectors/` for a future crawler (later)
+
+**Acceptance criteria**
+- SEO runs produce a “technical blockers first” list with evidence artifacts.
+
+## 6) Paid search / intent capture (Google Ads)
+**Gap**: no paid search connector means we miss a core “one-person marketing” lever (search terms, negatives, landing page alignment).
+
+**Spec to add**
+- Google Ads connector catalog + capabilities (search terms, negatives, keyword status, budgets)
+- WorkflowId: `paid_search_waste_cleanup` + `keyword_intent_alignment`
+
+**Where**
+- Add `docs/connectors/google_ads.md` (later v2 tool expansion)
+- Extend `docs/ROADMAP.md` and `docs/WORKFLOWS.md`
+
+**Acceptance criteria**
+- A weekly paid-search workflow can propose negatives and measurement of waste reduction.
+
+## 7) Lifecycle + CRM data model depth
+**Gap**: connector catalogs exist, but we don’t specify the canonical event/object mapping for lifecycle.
+
+**Spec to add**
+- Lifecycle stage mapping policy (context-driven)
+- Segment definitions and naming conventions
+- SLA definitions + leak detection thresholds
+
+**Where**
+- Add `docs/LIFECYCLE.md`
+- Extend `docs/SPECS.md` context with `lifecycle.stageMap`, `lifecycle.slas`
+
+**Acceptance criteria**
+- Weekly review can reliably explain stage leakage and recommend actions tied to stage definitions.
+
+## 8) Planning → project execution handoff (non-API work)
+**Gap**: ChangeSets model tool ops, but not human tasks (design, approvals, stakeholder review).
+
+**Spec to add**
+- `mar21.todo.*` op family spec (create/update/close tasks)
+- Task store choices (v1: local `todos.yaml`; later: Jira/Linear/Asana connectors)
+
+**Where**
+- Add `docs/TASKS.md`
+- Extend `schemas/changeset.schema.json` examples to include `mar21.todo.create`
+
+**Acceptance criteria**
+- GTM plans produce an actionable task backlog with owners and measurement.
+
+### Status
+Initial v1 spec added:
+- `docs/TASKS.md`
+- `schemas/todos.schema.json`
+- `examples/todos.yaml`
+
+## 9) Memory as a system (promotion + conflict resolution)
+**Gap**: memory files exist, but no “how we update and trust memory” spec.
+
+**Spec to add**
+- Memory entry structure (claim, evidence refs, confidence, last reviewed)
+- Promotion rules and review workflow (supervised)
+- Conflict resolution (two learnings disagree)
+
+**Where**
+- Add `docs/MEMORY.md`
+- Add schemas for memory files (optional)
+
+**Acceptance criteria**
+- Skills can reference memory entries deterministically and safely update them via ChangeSet ops.
+
+## 10) Workspace inheritance (shared defaults vs overrides)
+**Gap**: `_cfg/` exists, but no spec for “global defaults” across many workspaces.
+
+**Spec to add**
+- Global config layer: `_cfg-global/` or `defaults/` (repo-level)
+- Precedence: core < global < workspace context < workspace `_cfg/`
+
+**Where**
+- Extend `docs/DEV.md` and `docs/SPECS.md`
+
+**Acceptance criteria**
+- Multi-brand operators can update a policy once and have it apply everywhere (unless overridden).
+
+## 11) Run economics + prioritization (what to do next)
+**Gap**: no explicit scoring model for prioritizing work under constraints.
+
+**Spec to add**
+- Scoring rubric (ICE/RICE or constraint-aware ROI)
+- “Do next” output artifact (`outputs/next_actions.md` + JSON)
+
+**Where**
+- Add `docs/PRIORITIZATION.md`
+- Extend `docs/EVALS.md` to require prioritization rationale for weekly/monthly plans
+
+**Acceptance criteria**
+- Weekly plan includes ranked actions with explicit expected impact + evidence.

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -1,0 +1,128 @@
+# mar21 Best Practices (Evidence-Based Principles)
+
+`mar21` is a marketing OS, not a tool wrapper. That means we encode **principles** into:
+- workspace context fields,
+- skills and workflow defaults,
+- evaluation rubrics,
+- and mandatory run artifacts (evidence, sources, decision logs).
+
+This doc lists the **non-negotiable marketing principles** `mar21` should reflect, and how we weave them into the boilerplate foundation.
+
+## 1) Balance long-term brand building and short-term activation
+**Principle**: sustainable growth requires investing in both long-term effects (brand) and short-term effects (activation), measured and planned explicitly.
+
+**Evidence**: IPA summary presentation “The Long and the Short of It” (Binet & Field) summarizes principles including integrating brand and activation, share of voice, and measuring short + long-term effects. [R1]
+
+**How `mar21` encodes it**
+- Context: add a budget split and time-horizon policy (brand vs activation; 90-day vs 12-month goals).
+- Workflows: monthly loop must produce a “brand vs activation” section and a spend allocation rationale.
+- Evals: reports must include “short vs long-term effects” notes and planned measurement windows.
+
+## 2) Reach category buyers; don’t over-index on narrow targeting
+**Principle**: growth usually comes from reaching a broad set of category buyers, not only hyper-targeted segments.
+
+**Evidence**: IPA “The Long and the Short of It” includes “Talk to all your prospects” as a key principle. [R1]
+
+**How `mar21` encodes it**
+- Context: capture the “targeting posture” (broad reach vs narrow) as an explicit choice with guardrails.
+- Paid workflows: require a “reach vs precision” tradeoff statement and a test plan.
+
+## 3) Create helpful, people-first content; treat E‑E‑A‑T as quality alignment
+**Principle**: content should be created for people (beneficial purpose), and demonstrate trust through experience/expertise/authority signals appropriate to the topic.
+
+**Evidence**: Google’s “Creating helpful, reliable, people-first content” explains E‑E‑A‑T, states trust is most important, and clarifies E‑E‑A‑T is not a single ranking factor but a useful concept for aligning with signals. [R2]
+
+**How `mar21` encodes it**
+- Artifacts: for strategy and content work, require `outputs/research_pack.md` with attributable sources and `outputs/decision_log.md`.
+- Content skills: include an `content.eeat_review` step that checks “Who/How/Why” clarity and trustworthiness fit for purpose.
+- Evals: research packs require citations; reports must link claims to evidence.
+
+## 4) Trust is primary; reputation and independent evidence matter
+**Principle**: trust is not only on-page copy—reputation and independent evidence affect perceived quality and decisions.
+
+**Evidence**: Google’s Search Quality Rater Guidelines emphasize trust as the most important part of E‑E‑A‑T, and recommend evaluating what creators say, what others say (independent sources), and what’s visible/testable on the page. [R3]
+
+**How `mar21` encodes it**
+- Research workflow: explicitly includes “what others say” sources (public press, reviews, third-party analysis) when applicable.
+- Memory: store reputational learnings and recurring objections in `memory/learnings.yaml`.
+
+## 5) SEO fundamentals: crawlability and comprehension before tactics
+**Principle**: SEO starts with eligibility (crawl/index/understand), then content and presentation; avoid superstition tactics.
+
+**Evidence**: Google’s SEO Starter Guide focuses on crawlability, descriptive URLs, and calls out common misconceptions. [R4]
+
+**How `mar21` encodes it**
+- SEO workflow outputs: include a “technical blockers first” checklist and evidence from GSC.
+- Skills: `seo.technical_readiness_check` and `seo.snippet_quality_check` produce evidence artifacts and a ChangeSet of safe tasks.
+
+## 6) Writing must be scannable and understandable (plain language)
+**Principle**: web users scan; plain language increases comprehension and reduces friction.
+
+**Evidence**: U.S. government guidance defines plain language as communication your audience can understand the first time they read or hear it; usability research shows users scan and skim web pages. [R5] [R8]
+
+**How `mar21` encodes it**
+- Copy skills: `copy.plain_language_check` and `copy.scannability_check` become default gates for landing pages and emails.
+- Evals: plan/report templates require “first-time comprehension” checks and simplified CTA language.
+
+## 7) Measure what matters: avoid proxy traps
+**Principle**: optimize for business outcomes, not proxies that can be gamed (CTR, sessions) without profit impact.
+
+**Evidence**: Experimentation research highlights the risk of over-relying on proxy metrics and flawed heuristics; Goodhart-like dynamics show how targets can corrupt measures. [R6] [R7]
+
+**How `mar21` encodes it**
+- Context: define primary KPI and allowed proxy KPIs per workflow.
+- Evals: reports must include a KPI tree and state which node the proposed actions target.
+
+## 8) Join data across tools; always disclose attribution reality
+**Principle**: channel data is partial; decisions must use joins (UTM + naming) and disclose uncertainty/unattributed share.
+
+**Evidence**: Google guidance emphasizes user-first content and transparency; `mar21` operationalizes this through explicit evidence links and “Measurement Reality” disclosures. [R2] [R4]
+
+**How `mar21` encodes it**
+- Data model: canonical metrics/dimensions and join confidence in `docs/DATA_MODEL.md`.
+- Reports: mandatory attribution disclaimer section and unattributed share.
+
+## 9) Deep research + sparring is part of strategy (AI-augmented)
+**Principle**: strategy is human-owned but should be AI-augmented via deep research and sparring that pressure-tests assumptions.
+
+**Evidence**: Google’s guidance and rater framework stress trust, original helpfulness, and aligning with what people seek; `mar21` extends this into strategy artifacts with sources and explicit assumptions. [R2] [R3]
+
+**How `mar21` encodes it**
+- Workflow: `deep_research_sparring` produces `research_pack.md` (sources) and `decision_log.md`.
+- Drive: private-doc ingestion allowed by default (supervised) with caps and redaction.
+
+## 10) Build and protect distinctive assets (consistency compounds)
+**Principle**: being recognized quickly and consistently reduces friction and increases effectiveness across channels.
+
+**Evidence**: IPA “The Long and the Short of It” emphasizes the role of distinctive brand assets and creative consistency for effectiveness. [R1]
+
+**How `mar21` encodes it**
+- Context: store `brand.distinctiveAssets` and category entry points; require using them in briefs/copy.
+- Memory: persist “winning” assets and variations with evidence links.
+- Evals: content and ad drafts must include the declared assets unless the plan explicitly justifies deviation.
+
+## 11) Creativity is an efficiency lever (not decoration)
+**Principle**: creative quality is a first-order driver of marketing efficiency; treat it as measurable work.
+
+**Evidence**: IPA “The Long and the Short of It” includes “Creativity is the key to effectiveness” and “Creativity increases efficiency”. [R1]
+
+**How `mar21` encodes it**
+- Workflows: ads and content workflows must output a creative test plan (what will be varied, why, how measured).
+- Evals: plans must state the creative hypothesis and primary success metric (not only CTR).
+
+## Boilerplate weaving checklist (implementation-facing)
+When we start coding `repo/`, these principles must appear as:
+1) Context fields (explicit choices, constraints, budgets, measurement)
+2) Default workflow steps (research → evidence → plan → changeset)
+3) Skill gates (plain language, E‑E‑A‑T fit-for-purpose, technical eligibility checks)
+4) Evals (schema + rubric compliance; citations required for research)
+
+## References
+- [R1] IPA — “The long and the Short of it presentation” (Binet & Field): https://ipa.co.uk/knowledge/documents/the-long-and-the-short-of-it-presentation
+- [R2] Google Search Central — “Creating helpful, reliable, people-first content”: https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+- [R3] Google — Search Quality Evaluator Guidelines (PDF): https://static.googleusercontent.com/media/guidelines.raterhub.com/en//searchqualityevaluatorguidelines.pdf
+- [R4] Google Search Central — “SEO Starter Guide: The Basics”: https://developers.google.com/search/docs/fundamentals/seo-starter-guide
+- [R5] Digital.gov — “An introduction to plain language”: https://digital.gov/resources/an-introduction-to-plain-language
+- [R6] “Profit over Proxies: A Scalable Bayesian Decision Framework for Optimizing Multi-Variant Online Experiments” (arXiv): https://arxiv.org/abs/2509.22677
+- [R7] Goodhart’s law (summary): https://en.wikipedia.org/wiki/Goodhart%27s_law
+- [R8] Nielsen Norman Group — “How Users Read on the Web”: https://www.nngroup.com/articles/how-users-read-on-the-web/

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,126 @@
+# mar21 CLI Spec
+
+This document defines the **exact** CLI surface and UX expectations. Implementers should not have to guess flags, outputs, prompts, or exit codes.
+
+## Command grammar
+
+### Core verbs
+```
+mar21 init --workspace <id> [--force]
+
+mar21 plan <workflowId> --workspace <id> [--mode <mode>] [--since <duration>] [--dry-run] [--json]
+mar21 analyze <scope> --workspace <id> [--mode <mode>] [--since <duration>] [--dry-run] [--json]
+mar21 report <cadence|workflowId> --workspace <id> [--since <duration>] [--json]
+
+mar21 run daily|weekly|monthly --workspace <id> [--profile <profileId>] [--mode <mode>] [--dry-run] [--json]
+mar21 autopilot start --workspace <id> --profile <profileId> [--mode <mode>] [--dry-run] [--foreground]
+
+mar21 apply <runId> --workspace <id> [--yes] [--json]
+```
+
+### Optional task convenience commands (v1)
+These commands are optional sugar over `todos.yaml` + `mar21.todo.*` ops:
+```
+mar21 tasks list --workspace <id> [--status open|in_progress|blocked]
+mar21 tasks show <taskId> --workspace <id>
+mar21 tasks close <taskId> --workspace <id> [--status done|canceled] [--note <text>]
+```
+They must not bypass the audit trail: mutations should still be recorded as a run with a ChangeSet op.
+
+### Optional namespaces (aliases only)
+These do not change semantics; they map to workflows/skills for discoverability:
+```
+mar21 seo plan <workflowId> ...
+mar21 ads plan <workflowId> ...
+mar21 content plan <workflowId> ...
+mar21 crm plan <workflowId> ...
+```
+
+## Global flags and precedence
+- `--workspace <id>` selects `workspaces/<id>/`.
+- `MAR21_WORKSPACE` is used only if `--workspace` is absent.
+- `--mode advisory|supervised|autonomous` overrides:
+  - `constraints.autonomy.defaultMode` in the context, and
+  - any profile step mode (unless a step explicitly pins a higher-safety mode).
+- `--dry-run` forces: never apply tool writes (ChangeSet still produced).
+- `--since <duration>` uses ISO 8601 duration strings (e.g. `P7D`, `P28D`, `P90D`).
+- `--json` prints a machine-readable run summary to stdout.
+
+## Run id format
+Run ids must be filesystem-safe and sortable:
+
+`<UTC timestamp>_<workflowId>`
+
+Example:
+- `2026-03-11T101530Z_weekly_review`
+
+Rules:
+- timestamp is UTC in `YYYY-MM-DDTHHMMSSZ`
+- workflowId is slugified (`[a-z0-9_]+`)
+- on collision, append `_<n>` (e.g. `_2`, `_3`)
+
+## Output locations
+All runs write to:
+- `workspaces/<ws>/runs/<runId>/`
+
+Required run files (see `docs/SPECS.md`):
+- `inputs/context.snapshot.yaml`
+- `inputs/request.yaml`
+- `outputs/plan.md`
+- `outputs/report.md`
+- `changeset.yaml`
+- `logs.jsonl`
+- `run.json`
+- `approvals.json` (may be empty if no approvals were requested)
+
+## Interactive prompts
+
+### Applying ChangeSets
+For each op where `requiresApproval: true`, the CLI must display:
+- op id, tool, operation, risk
+- reason (if provided)
+- expected impact (if provided)
+- rollback hint (if provided)
+- evidence references (if provided)
+
+Prompt:
+- `Approve this operation? (y/n) `
+
+If rejected, the CLI must:
+- record a rejection entry in `approvals.json`
+- skip the op
+- continue to the next op (unless `--fail-on-reject` is introduced later; not in v1)
+
+### Sensitive reads exceeding caps (Drive exports/downloads)
+If a run would exceed caps (e.g. `maxDownloads`, `maxFileSizeMB`):
+- prompt: `This run will download/export N files (~X MB). Continue? (y/n) `
+- record the decision in `logs.jsonl` (no private URLs)
+
+## Exit codes
+`mar21` uses conventional Unix exit codes:
+- `0` success
+- `2` invalid usage (unknown command, missing required arg)
+- `10` workspace not found / invalid workspace
+- `11` schema validation failed (context/request/changeset)
+- `20` connector auth missing or invalid
+- `21` connector rate-limited beyond retry budget
+- `30` apply failed (partial apply possible; see stdout/logs)
+
+If an apply is partial:
+- exit `30`
+- include per-op results in `logs.jsonl` and `--json` output
+
+## `--json` output (run summary)
+When `--json` is set, stdout must include a single JSON object:
+```json
+{
+  "runId": "2026-03-11T101530Z_weekly_review",
+  "workspace": "acme",
+  "workflowId": "weekly_review",
+  "mode": "supervised",
+  "paths": {
+    "runDir": "workspaces/acme/runs/2026-03-11T101530Z_weekly_review",
+    "changeset": "workspaces/acme/runs/2026-03-11T101530Z_weekly_review/changeset.yaml"
+  }
+}
+```

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,0 +1,238 @@
+# mar21 Connectors (Integration Spec)
+
+Connectors are the **API boundary** between `mar21` and external marketing tools. A connector is not “a thin client”—it is a **capability-declaring, safety-aware module** that makes tool operations:
+- discoverable (capabilities manifest),
+- auditable (run artifacts + logs),
+- safe (risk levels + dry-run + approvals),
+- portable (tool semantics are mapped into stable ops).
+
+This document defines **v1 tool scope** and **capability boundaries**.
+
+v1 first-class tools:
+- SEO: Google Search Console (`gsc`)
+- Analytics: GA4 (`ga4`)
+- Ads: Meta Ads (`meta_ads`)
+- CRM: HubSpot (`hubspot`)
+- Commerce: Shopify (`shopify`)
+- CMS: WordPress (`wordpress`)
+- Comms: Slack (`slack`)
+- Email: Klaviyo (`klaviyo`)
+- Private docs: Google Drive (`gdrive`, all file types)
+
+For exhaustive per-tool capability catalogs, see `docs/connectors/README.md`.
+
+Research packs may also cite **private documents** (Notion/Drive/Confluence/etc.). In v1 this can be handled as:
+- manual doc refs inside `outputs/research_pack.md`, and/or
+- local files placed into `runs/<id>/inputs/` (treated as private evidence),
+with dedicated “docs connectors” being a later expansion.
+
+Priority private-doc connector:
+- **Google Drive / Google Docs (`gdrive`)**
+
+## Connector rules (non-negotiable)
+- **Least privilege by default**: prefer read-only scopes; write scopes are explicit and separable.
+- **Dry-run always** for write ops: validate + compute intended effect without applying.
+- **Rate limits are first-class**: connectors own retry/backoff; orchestrator treats them as bounded resources.
+- **No PII in logs**: redact at the connector boundary.
+- **Capability naming is stable**: skills reference capability ids, not SDK methods.
+
+## Capability naming convention
+Capability ids follow:
+
+`<tool>.<read|write>.<resource>.<verb>`
+
+Examples:
+- `ga4.read.report.run`
+- `gsc.read.search_analytics.query`
+- `meta_ads.read.insights.by_adset`
+- `wordpress.write.post.create_draft`
+- `slack.write.message.post`
+
+## Risk model for connector ops
+Each capability must declare a risk level:
+- **low**: reversible, bounded impact, no user-visible negative outcomes expected (e.g. Slack post)
+- **medium**: changes live systems, but reversible and bounded (e.g. pause ad set, create WP draft)
+- **high**: irreversible or potentially large monetary/brand impact (e.g. publish content, large budget changes)
+
+`mar21` is supervised-by-default: medium/high writes require approval unless allowlisted.
+
+## v1 connector boundaries (per tool)
+
+### Google Search Console (`gsc`)
+**Primary purpose:** organic demand + performance signals (queries, pages, CTR, position).
+
+**Must-have reads (v1)**
+- `gsc.read.search_analytics.query` (by query/page/country/device)
+
+**Optional reads (later)**
+- indexing coverage, sitemaps, manual actions, core web vitals surfaces
+
+**Writes (v1)**
+- none (GSC is treated as read-first for v1)
+
+**Common pitfalls**
+- sampling/aggregation differences by dimension selection
+- timezone alignment (use GA4 timezone strategy in context)
+
+### GA4 (`ga4`)
+**Primary purpose:** funnel truth, conversions, channel performance, baseline/anomaly signals.
+
+**Must-have reads (v1)**
+- `ga4.read.report.run` (sessions, users, conversions, revenue; by channel/campaign/landing page)
+
+**Writes (v1, optional)**
+- `ga4.write.annotation.create` (**medium**) — annotate runs (if supported/available in your setup)
+
+**Common pitfalls**
+- conversion definitions drift; context must declare “what counts”
+- attribution settings differ from ad platforms; report must call this out
+
+### Meta Ads (`meta_ads`)
+**Primary purpose:** paid social execution and operational excellence (structure, fatigue, waste).
+
+**Must-have reads (v1)**
+- `meta_ads.read.insights.by_campaign`
+- `meta_ads.read.insights.by_adset`
+- `meta_ads.read.insights.by_ad`
+
+**Writes (v1, supervised)**
+- `meta_ads.write.adset.pause` (**medium**)
+- `meta_ads.write.campaign.pause` (**medium/high** depending on spend)
+- `meta_ads.write.budget.update` (**high** unless tightly bounded)
+
+**Common pitfalls**
+- performance is non-stationary; require “evidence window” in reports (e.g. P7D vs P28D)
+- creative fatigue metrics are proxies; always include “confidence level”
+
+### HubSpot (`hubspot`)
+**Primary purpose:** lead lifecycle truth (MQL→SQL→Closed Won), hygiene, SLA checks, nurture gaps.
+
+**Must-have reads (v1)**
+- `hubspot.read.deals.list`
+- `hubspot.read.contacts.list` (limited fields; no full exports by default)
+- `hubspot.read.lifecycle.metrics` (aggregations)
+
+**Writes (v1, supervised)**
+- `hubspot.write.property.update` (**medium**) — standardize lifecycle fields
+- `hubspot.write.task.create` (**low/medium**) — create follow-up tasks
+
+**Common pitfalls**
+- lifecycle definitions vary by org; context must define the mapping
+- avoid pulling/storing full contact PII; aggregate by default
+
+### Shopify (`shopify`)
+**Primary purpose:** revenue truth, cohorts, product/category signals.
+
+**Must-have reads (v1)**
+- `shopify.read.orders.list` (minimal fields, aggregated)
+- `shopify.read.customers.cohorts` (derived from orders)
+
+**Writes (v1)**
+- none by default (treat commerce writes as higher risk)
+
+**Common pitfalls**
+- refunds/chargebacks: define how they affect “revenue” in KPI tree
+- multi-currency: context currency rules must be explicit
+
+### WordPress (`wordpress`)
+**Primary purpose:** content execution with safety (draft-first).
+
+**Must-have reads (v1)**
+- `wordpress.read.post.list`
+- `wordpress.read.page.list`
+
+**Writes (v1, draft-only)**
+- `wordpress.write.post.create_draft` (**medium**)
+- `wordpress.write.post.update_draft` (**medium**)
+
+**Writes (later, high risk)**
+- publish/update live pages (**high**, never autonomous by default)
+
+**Common pitfalls**
+- formatting/HTML block differences; preserve structure and keep edits minimal
+
+### Slack (`slack`)
+**Primary purpose:** operator notifications, digests, approvals coordination.
+
+**Reads (v1)**
+- none required
+
+**Writes (v1)**
+- `slack.write.message.post` (**low**)
+- `slack.write.thread.reply` (**low**)
+
+### Klaviyo (`klaviyo`)
+**Primary purpose:** lifecycle operations (flows, campaigns, tests, segments).
+
+**Must-have reads (v1)**
+- `klaviyo.read.flows.list`
+- `klaviyo.read.campaigns.list`
+- `klaviyo.read.metrics.aggregate`
+
+**Writes (v1, supervised)**
+- `klaviyo.write.draft.update` (**medium**)
+
+**Writes (later, high risk)**
+- send/schedule campaigns (**high** by default)
+
+### Google Drive (all file types) (`gdrive`) — priority private-doc connector
+**Primary purpose:** bring private strategy docs, memos, interview syntheses, research notes, and attachments (Docs/Sheets/Slides/PDFs/images/etc.) into runs **safely** (reference-first, excerpt-minimal).
+
+**Must-have reads (v1)**
+- `gdrive.read.files.search` (**low**) — find docs by folder, name, query, modified time
+- `gdrive.read.files.get_metadata` (**low**) — title, owner, modified time (no content)
+- `gdrive.read.files.download` (**medium**) — download non-Google file bytes (PDFs, images, office docs)
+- `gdrive.read.files.export` (**low/medium**) — export Google Workspace files (Docs/Sheets/Slides) into a target format for evidence packs
+
+**Default policy (allowed by default)**
+- In `supervised` mode, `gdrive.read.files.download` and `gdrive.read.files.export` are **allowed by default** (no allowlist needed).
+- The orchestrator should still apply **GDPR-first minimization**:
+  - metadata-first,
+  - download/export only when a file is referenced by id/ref in the request, or when included as evidence for a specific finding,
+  - prefer excerpts + redaction over storing whole files.
+
+Recommended read capability aliases (convenience names)
+- `gdrive.read.docs.export_markdown` (**low/medium**) → `files.export` to Markdown/plaintext
+- `gdrive.read.sheets.export_csv` (**low/medium**) → `files.export` to CSV
+- `gdrive.read.slides.export_pdf` (**low/medium**) → `files.export` to PDF
+- `gdrive.read.pdf.extract_text` (**medium**) → download PDF then extract text (via a skill) with redaction
+
+**Writes (default: none)**
+- Treat Drive as **read-first**. Creating/modifying docs is **high risk** (accidental leakage / policy issues) and should be “later”.
+
+**Safe evidence pattern**
+- Prefer citing Drive docs by ref in `research_pack.md`:
+  - `drive:fileId:<id>` (preferred), or `drive:<id>`
+- If excerpts are needed (recommended default):
+  - export/download only what’s needed for the current research question,
+  - extract text/tables via a skill,
+  - redact,
+  - store the excerpt as `outputs/evidence/gdrive_<fileId>.<ext>`,
+  - cite that excerpt as `internal_snapshot` and the original file as `private_doc`.
+- If storing full files is necessary (exception):
+  - store in `outputs/evidence/` with a clear filename,
+  - record `sha256` and a retention note,
+  - avoid re-distribution; treat runs as private.
+
+**Common pitfalls**
+- Docs often contain names/emails; default to summaries and aggressively redact.
+- Don’t store secret-bearing URLs; store refs (file ids) only.
+- Large binaries (videos, huge PDFs) bloat runs; prefer metadata + small excerpts unless explicitly requested.
+  
+## Auth defaults (local-first)
+Connector secrets live in `workspaces/<workspace>/secrets/.env` (never committed).
+Recommended pattern:
+- one read-only credential set
+- one write-enabled credential set (separate env vars), activated only when needed
+
+### Env var naming convention (recommended)
+Use `MAR21_<TOOL>_<NAME>` to keep secrets predictable:
+- `MAR21_GA4_CLIENT_ID`, `MAR21_GA4_CLIENT_SECRET`, `MAR21_GA4_REFRESH_TOKEN`
+- `MAR21_GSC_CLIENT_ID`, `MAR21_GSC_CLIENT_SECRET`, `MAR21_GSC_REFRESH_TOKEN`
+- `MAR21_META_ADS_ACCESS_TOKEN` (or OAuth tokens)
+- `MAR21_HUBSPOT_PRIVATE_APP_TOKEN`
+- `MAR21_SHOPIFY_ACCESS_TOKEN`, `MAR21_SHOPIFY_STORE_DOMAIN`
+- `MAR21_WORDPRESS_BASE_URL`, `MAR21_WORDPRESS_APP_PASSWORD`
+- `MAR21_SLACK_BOT_TOKEN`
+- `MAR21_KLAVIYO_PRIVATE_API_KEY`
+- `MAR21_GDRIVE_CLIENT_ID`, `MAR21_GDRIVE_CLIENT_SECRET`, `MAR21_GDRIVE_REFRESH_TOKEN`

--- a/docs/CREATIVE.md
+++ b/docs/CREATIVE.md
@@ -1,0 +1,193 @@
+# mar21 Creative System (Production Pipeline)
+
+This document specifies how `mar21` treats creative as a **measurable system**:
+- briefs are structured,
+- assets are versioned and attributable,
+- variation is intentional (hypothesis-driven),
+- fatigue is monitored,
+- distinctive assets are enforced and compounded via memory.
+
+The goal is to make “creative” operable by a one-person team without devolving into random iterations.
+
+## Principles
+- **Creative is a first-order efficiency lever**: we treat it like product work, not decoration.
+- **Assets are tracked**: every creative unit has an id, a hypothesis, and measurement hooks.
+- **Draft-first**: publishing/sending is high risk; drafts and plans come first.
+- **Evidence-backed**: creative decisions cite run evidence and sources.
+
+## Core artifacts (per run)
+When a workflow touches creative, the run should produce:
+- `outputs/creative_brief.md` (human-readable brief)
+- `outputs/creative_brief.yaml` (machine-readable brief)
+- `outputs/asset_manifest.yaml` (assets planned/created/updated)
+- `outputs/creative_matrix.yaml` (variation system: angles × formats × audiences)
+- `outputs/creative_fatigue.json` (fatigue signals and thresholds; if ad data available)
+- `outputs/decision_log.md` (decisions + tradeoffs + what changes our mind)
+
+## 1) Creative brief (contract)
+
+### 1.1 Brief fields (required)
+`outputs/creative_brief.yaml`:
+```yaml
+apiVersion: mar21/creative-brief-v1
+runId: 2026-03-12T090000Z_meta_cleanup
+workspace: acme
+
+goal:
+  kpiNode: conversions
+  successMetric: cpa
+  target: "CPA <= 45 EUR (P7D)"
+
+audience:
+  segmentRef: "icp.segments[0]"
+  pains: ["manual reporting", "tool sprawl"]
+  objections: ["too complex", "no time"]
+
+offer:
+  promise: "Weekly review that ships actions, not dashboards."
+  proof: ["case study", "demo video", "screenshots"]
+  cta: "Book a 15‑min audit"
+
+message:
+  angle: "auditable growth loops"
+  supportPoints:
+    - "Plan/Report/ChangeSet every week"
+    - "Supervised-by-default"
+  doNotSay: ["guaranteed outcomes"]
+
+constraints:
+  brandAssetsRequired: true
+  eeatRequired: true
+  plainLanguageRequired: true
+  legalNotes: []
+
+tracking:
+  utm:
+    required: true
+    utm_source: "meta"
+    utm_medium: "paid_social"
+    utm_campaign: "prospecting_auditability"
+```
+
+### 1.2 Brief output (human)
+`outputs/creative_brief.md` is the same content, optimized for quick review:
+- what are we trying to change (KPI node + window)
+- who is this for (segment + pains + objections)
+- what’s the promise and proof
+- what must remain consistent (distinctive assets, claims policy)
+- what we will vary and why (creative matrix)
+
+## 2) Asset manifest (IDs, versions, and lineage)
+
+### 2.1 Asset id format (stable)
+Asset ids must be deterministic and filesystem-safe:
+
+`<channel>_<format>_<angle>_<yyyy-mm>_<vN>`
+
+Examples:
+- `meta_video_auditability_2026-03_v1`
+- `wp_post_category-entry-point_2026-03_v2`
+- `email_subject_activation_fix_2026-03_v3`
+
+### 2.2 Asset manifest fields (required)
+`outputs/asset_manifest.yaml`:
+```yaml
+apiVersion: mar21/asset-manifest-v1
+runId: 2026-03-12T090000Z_meta_cleanup
+workspace: acme
+
+assets:
+  - assetId: meta_video_auditability_2026-03_v1
+    channel: meta_ads
+    format: video
+    status: planned # planned|draft|active|paused|retired
+    briefRef: outputs/creative_brief.yaml
+    hypothesisRef: HYP-001
+    distinctiveAssetsUsed:
+      - "brand.distinctiveAssets[tagline]"
+    files:
+      - path: outputs/evidence/assets/meta_video_auditability_2026-03_v1.mp4
+        sha256: "…"
+    landingPageRef: "https://example.com/audit"
+    tracking:
+      utm_campaign: prospecting_auditability
+    measurement:
+      primaryMetric: cpa
+      window: P7D
+```
+
+### 2.3 Lineage rules
+When replacing/iterating an asset:
+- create a new `assetId` version (`_v2`, `_v3`, …)
+- link to prior `assetId` in `notes` or a `derivedFrom` field (optional)
+- never overwrite evidence for old assets in prior runs
+
+## 3) Creative matrix (variation system)
+The creative matrix is the “system” that prevents random testing.
+
+`outputs/creative_matrix.yaml`:
+```yaml
+apiVersion: mar21/creative-matrix-v1
+runId: 2026-03-12T090000Z_meta_cleanup
+workspace: acme
+
+angles:
+  - id: ANG-001
+    name: "Auditability"
+    claim: "Plan/Report/ChangeSet every week"
+  - id: ANG-002
+    name: "Waste reduction"
+    claim: "Reduce wasted ad spend with supervised changes"
+
+formats:
+  - id: FMT-001
+    name: "Short video"
+  - id: FMT-002
+    name: "Static image"
+
+audiences:
+  - id: AUD-001
+    name: "Ops-led SaaS"
+
+tests:
+  - id: TST-001
+    angleId: ANG-001
+    formatId: FMT-001
+    audienceId: AUD-001
+    hypothesisRef: HYP-001
+    successMetric: cpa
+    window: P7D
+    guardrails:
+      maxSpendEUR: 500
+```
+
+## 4) Creative fatigue tracking (operational)
+Fatigue is tracked when we have channel data (Meta Ads in v1).
+
+`outputs/creative_fatigue.json` should include:
+- asset or ad id mapping
+- performance deltas vs baseline (P7D vs P28D)
+- fatigue flags (e.g., rising CPA, falling CTR, rising frequency)
+- recommended action (refresh, pause, broaden, rotate)
+
+Fatigue recommendations must produce ChangeSet ops (supervised):
+- pause/rotate assets (bounded)
+- create new drafts
+
+## 5) Distinctive assets (memory and enforcement)
+Distinctive assets are stored and evolved explicitly.
+
+Recommended memory files:
+- `memory/distinctive_assets.yaml` (what must stay consistent)
+- `memory/creative_learnings.yaml` (what works/doesn’t, with evidence)
+
+Memory updates are proposed via ChangeSet ops (`mar21.memory.update`) and approved.
+
+## 6) WorkflowIds that produce creative artifacts
+These workflows should (eventually) emit the artifacts above:
+- `meta_cleanup` (ads creative refresh plan + fatigue)
+- `demand_capture` (briefs + on-page copy gates)
+- `lifecycle_revenue_loop` (email copy/subject test matrix)
+- `landing_page_iteration` (page variants + copy gates)
+- `creative_pipeline_weekly` (dedicated creative system run; see `docs/DISTRIBUTION.md` for distribution coupling)
+

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,0 +1,117 @@
+# mar21 Data Model (Marketing Truth Layer)
+
+This document defines canonical metrics, dimensions, joins, and attribution disclaimers. It exists to prevent “metric drift” across tools.
+
+## Canonical metrics (v1)
+All metrics are represented in a canonical namespace regardless of source tool.
+
+### Spend & efficiency
+- `spend` (money)
+- `clicks`
+- `impressions`
+- `cpc = spend / clicks`
+- `cpm = spend / impressions * 1000`
+
+### Funnel & revenue
+- `sessions` (GA4)
+- `users` (GA4)
+- `conversions` (GA4-defined; must be declared in context)
+- `leads` (HubSpot aggregation; definition must be declared in context)
+- `orders` (Shopify)
+- `revenue_gross` (Shopify/GA4)
+- `revenue_net` (optional; refunds/chargebacks policy required)
+
+### Outcome ratios
+- `cvr = conversions / sessions`
+- `cpa = spend / conversions` (or spend / leads; specify denominator)
+- `roas = revenue / spend` (specify which revenue and time window)
+
+## Canonical dimensions (v1)
+- `date` (ISO date or timestamp; windowing must be explicit)
+- `source` (canonical channel source)
+- `medium`
+- `campaign`
+- `content`
+- `term`
+- `landing_page` (normalized URL path)
+- `geo_country`
+- `device`
+- `platform` (tool id: `ga4`, `meta_ads`, etc.)
+
+### Creative/distribution dimensions (v1, recommended)
+To make creative and distribution measurable, prefer these dimensions where possible:
+- `creative_asset_id` (from asset manifest)
+- `creative_angle`
+- `creative_format`
+- `distribution_channel` (owned/paid/earned + tool id)
+- `distribution_touchpoint` (e.g. “newsletter”, “community_post”, “partner_email”)
+
+## Windowing & rounding rules
+- All time windows are expressed as ISO 8601 durations: `P7D`, `P28D`, `P90D`.
+- Reports must clearly state:
+  - window used for each finding (e.g. “P7D vs P28D”)
+  - timezone used (from context `measurement.timezone`)
+- Rounding:
+  - money: 2 decimals
+  - ratios: 2–4 decimals in machine outputs; human report can round to 1–2 decimals
+
+## Currency normalization
+The context must declare `businessModel.pricing.currency` as the canonical currency.
+If multi-currency exists:
+- canonical reporting currency is required
+- conversions must state the exchange rate policy (later; out of v1 scope for implementation, but required as documentation in reports)
+
+## KPI tree computation
+`kpiTree` defines how goals decompose. The runner must:
+- compute lagging/leading metrics per the tree
+- explicitly annotate missing nodes as “unknown” instead of silently dropping them
+
+Example:
+- Pipeline → SQLs → MQLs → Sessions → Impressions
+
+## Attribution disclaimers (non-negotiable)
+`mar21` reports must always include an attribution note:
+- **GA4**: first-party measurement, subject to consent, tagging, and attribution settings.
+- **Meta Ads**: platform reporting, subject to modelled conversions, view-through, and attribution windows.
+- **Shopify**: commerce truth, subject to refunds/chargebacks and offline payments.
+
+Reports must:
+- never claim “the truth” when sources disagree
+- show differences as differences (and assign a confidence level)
+
+## Joins: how we connect sources
+
+### Primary join: UTM conventions (recommended)
+UTMs are the primary join key across ads → sessions → revenue.
+
+Required fields for join quality:
+- `utm_source`
+- `utm_medium`
+- `utm_campaign`
+
+Optional but recommended:
+- `utm_content`
+- `utm_term`
+
+In `mar21`, `utm_content` should prefer embedding `creative_asset_id` (or a stable alias) when feasible, so we can join performance back to creative decisions.
+
+### Fallback joins
+If UTMs are missing:
+- map using naming conventions (campaign name alignment)
+- map using landing page + date window proximity
+
+Fallback joins must:
+- label outputs with a lower confidence
+- create an “unattributed” bucket rather than forcing joins
+
+## Unattributed handling & confidence
+Any aggregation must include:
+- `attribution.confidence`: `high|medium|low`
+- `attribution.unattributed_share`: percentage of outcomes that cannot be joined
+
+## Required reporting section: “Measurement Reality”
+Every weekly/monthly report must include:
+- what sources were used
+- what joins were possible
+- where attribution conflicts exist
+- how much is unattributed

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -1,0 +1,82 @@
+# mar21 Development Guide
+
+This is the engineering guide for implementing the `mar21` boilerplate.
+
+## Tooling assumptions
+- Node.js: **20.x**
+- Package manager: **pnpm**
+- Repo shape: TypeScript/Node monorepo (see `docs/ARCHITECTURE.md`)
+
+## Workspace bootstrap (local)
+Conceptual flow:
+1) Create workspace skeleton:
+   - `mar21 init --workspace acme`
+2) Fill `workspaces/acme/marketing-context.yaml`
+3) Add secrets locally:
+   - `workspaces/acme/secrets/.env`
+4) Run a read-only workflow (advisory/supervised):
+   - `mar21 plan deep_research_sparring --workspace acme --since P90D`
+5) Inspect run artifacts in:
+   - `workspaces/acme/runs/<runId>/`
+
+## `_cfg/` overrides (update-safe customization)
+Each workspace may define:
+- `workspaces/<ws>/_cfg/`
+
+Purpose:
+- keep local customization **separate** from core defaults so upstream updates are easier to merge.
+
+Recommended contents:
+- `policies.yaml` (approval rules, caps, redaction)
+- `templates/` (Plan/Report templates)
+- `skills/` (workspace-specific skill config or wrappers)
+
+Precedence:
+1) core defaults (hard-coded / package defaults)
+2) `marketing-context.yaml`
+3) `_cfg/` overrides (highest precedence)
+
+## Adding a connector (end-to-end)
+1) Add connector manifest:
+   - `packages/connectors/<tool>/connector.yaml` (must validate with `schemas/connector.schema.json`)
+2) Implement capability ids in code (later):
+   - each capability is a stable operation name
+3) Add docs:
+   - `docs/connectors/<tool>.md` capability catalog
+4) Add tests/fixtures (later):
+   - schema validation tests
+   - dry-run behavior tests for writes
+
+## Adding a skill (end-to-end)
+1) Add manifest:
+   - `skills/<domain>/<skill>/skill.yaml` (validate with `schemas/skill.schema.json`)
+2) Define typed I/O:
+   - input and output schema in the manifest
+3) Define artifacts:
+   - required outputs and evidence refs
+4) Add docs:
+   - list the skill in the relevant workflow(s)
+5) Add fixtures (later):
+   - validate outputs against schema
+
+## Adding a workflowId
+1) Add workflow spec to `docs/WORKFLOWS.md` (id + command + artifacts)
+2) Ensure it maps cleanly to CLI grammar (`docs/CLI.md`)
+3) If it’s part of autopilot:
+   - add it to a profile (`workspaces/<ws>/profiles/*.yaml` shape in `docs/SPECS.md`)
+
+## Optional: packs and bundles (distribution)
+If you add “packs” (core + expansions):
+- keep core interfaces stable; packs can iterate faster
+- document pack provenance and versions
+- ship packs as folders under `packs/`
+
+If you export “bundles” for chat-first tools:
+- treat them as distribution artifacts under `dist/`
+- ensure bundles never bypass the stable surface (runs + changesets + approvals)
+
+## Recommended scripts (once code exists)
+Planned monorepo scripts:
+- `pnpm -w lint`
+- `pnpm -w test`
+- `pnpm -w validate` (schemas + examples)

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,125 @@
+# mar21 Distribution System (Owned / Earned / Paid)
+
+This document specifies how `mar21` operationalizes distribution:
+- content is not “done” at draft,
+- distribution is planned, versioned, and measured,
+- repurposing is explicit (one idea → many assets),
+- PR/community/partnership actions exist even when connectors don’t (as tasks).
+
+## Core artifacts (per distribution run)
+- `outputs/distribution_plan.md`
+- `outputs/distribution_plan.yaml`
+- `outputs/distribution_calendar.md` (next 7–30 days)
+- `outputs/repurpose_map.yaml` (source asset → derived assets)
+- `outputs/measurement_plan.md`
+- `changeset.yaml` containing:
+  - tool ops (WordPress drafts, Klaviyo drafts, Slack announcements)
+  - `mar21.todo.*` ops for non-API work (PR pitches, partner outreach)
+
+## 1) Distribution plan (contract)
+`outputs/distribution_plan.yaml`:
+```yaml
+apiVersion: mar21/distribution-plan-v1
+runId: 2026-03-12T090000Z_distribution_weekly
+workspace: acme
+since: P7D
+
+goal:
+  kpiNode: pipeline
+  target: "SQLs +10% (P28D)"
+
+sourceAssets:
+  - assetId: wp_post_category-entry-point_2026-03_v1
+    type: "pillar"
+    status: draft
+
+channels:
+  owned:
+    - id: wordpress
+      cadence: weekly
+    - id: email
+      provider: klaviyo
+      cadence: weekly
+  paid:
+    - id: meta_ads
+      cadence: ongoing
+  earned:
+    - id: pr
+      cadence: weekly
+    - id: community
+      cadence: weekly
+    - id: partnerships
+      cadence: monthly
+
+repurposingPolicy:
+  maxDerivedAssetsPerSource: 6
+  requireDistinctiveAssets: true
+  requirePlainLanguage: true
+
+tracking:
+  utmRequired: true
+  conventionsRef: measurement.utm.conventions
+```
+
+## 2) Repurpose map (one idea → many assets)
+`outputs/repurpose_map.yaml`:
+```yaml
+apiVersion: mar21/repurpose-map-v1
+runId: 2026-03-12T090000Z_distribution_weekly
+workspace: acme
+
+maps:
+  - sourceAssetId: wp_post_category-entry-point_2026-03_v1
+    derived:
+      - assetId: meta_static_auditability_2026-03_v1
+        channel: meta_ads
+        format: static
+      - assetId: email_subject_activation_fix_2026-03_v1
+        channel: email
+        format: subject_line
+      - assetId: slack_announcement_entry_point_2026-03_v1
+        channel: slack
+        format: message
+```
+
+## 3) Calendar (what ships, when, where)
+`outputs/distribution_calendar.md` must include:
+- date
+- channel
+- assetId
+- owner
+- measurement window + metric
+- status (draft/scheduled/live)
+
+## 4) PR / community / partnerships (no connector required)
+Until connectors exist, these are encoded as tasks:
+- pitch list + outreach plan
+- community posts
+- partner co-marketing requests
+
+These appear in ChangeSets as `mar21.todo.create` ops and are tracked like any other work.
+See `docs/TASKS.md` for the task contract and `todos.yaml` store.
+
+## 5) WorkflowId: `distribution_weekly`
+**Workflow ID:** `distribution_weekly`
+
+**Inputs**
+- latest drafts (WordPress/email/creative briefs)
+- `marketing-context.yaml` (goals + budgets + constraints)
+- optional: research pack summary for narrative alignment
+
+**Connectors (v1)**
+- WordPress (drafts)
+- Klaviyo (draft updates)
+- Meta Ads (context; optionally create “to-do” ops for new creatives)
+- Slack (announcements)
+
+**Artifacts**
+- distribution plan + calendar + repurpose map + measurement plan
+- ChangeSet containing a mix of tool ops and `mar21.todo.*` ops
+
+## 6) Distribution quality gates
+Distribution runs must:
+- declare which KPI node they target and why
+- include UTMs (or explicitly mark “untrackable” with low confidence)
+- avoid “spray and pray”: every channel action must map to a hypothesis and a measurement window

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -1,0 +1,114 @@
+# mar21 Evals (Quality Gates)
+
+This document defines what “good output” means and how runs can be regression-tested.
+
+## Goals
+- Prevent schema drift and broken artifacts.
+- Keep outputs comparable over time (especially weekly/monthly runs).
+- Ensure strategy artifacts (research/sparring) remain evidence-backed.
+
+## Hard gates (must always pass)
+1) **Schema validation**
+   - context, request, changeset, run.json must validate
+   - skill outputs must validate against each skill’s declared output schema
+2) **Required artifacts exist**
+   - Plan + Report + ChangeSet + logs.jsonl + run.json always present
+3) **Research pack source discipline**
+   - if `research_pack.md` exists, every major claim has `[S#]`
+   - Sources section includes: type + location ref + accessed date
+4) **Best-practice gates (when relevant)**
+   - if a workflow produces content drafts or landing-page variants, run the content gates below
+   - if a workflow produces SEO audits, run the SEO gates below
+
+## Rubrics (operator-facing)
+
+### Plan rubric (`outputs/plan.md`)
+Must include:
+- a single-sentence goal
+- KPI tree or KPI mapping
+- ranked hypotheses
+- tasks with:
+  - owner
+  - ETA or milestone date
+  - measurement definition (what metric, what window)
+- assumptions & open questions
+- guardrails (what will not be done)
+
+### Report rubric (`outputs/report.md`)
+Must include:
+- “What changed” with deltas and evidence references
+- “Why” with confidence labels
+- “What we did / will do” linked to ChangeSet ops
+- risks & unknowns
+- next checkpoint date/cadence
+- “Measurement Reality” section (joins, attribution conflicts, unattributed share)
+
+### Research pack rubric (`outputs/research_pack.md`)
+Must include:
+- research questions
+- findings with `[S#]` citations
+- implications (how this changes plan/positioning/channel mix)
+- gaps/unknowns
+- sources section with type + ref + accessed date
+
+### Content gates (when content artifacts exist)
+If a run produces content drafts (e.g. `outputs/*.md` intended for WordPress/email/ad copy), evaluate:
+- **People-first**: content is written for a user need (not for “rankings”)
+- **E‑E‑A‑T fit-for-purpose**: appropriate trust signals for the topic and claims
+- **Plain language**: comprehension-first and scannable structure
+
+These gates operationalize `docs/BEST_PRACTICES.md`.
+
+### Creative system gates (when creative artifacts exist)
+If a run produces:
+- `outputs/creative_brief.yaml`, `outputs/asset_manifest.yaml`, or `outputs/creative_matrix.yaml`
+
+Evaluate:
+- **Traceability**: every asset has an `assetId`, a brief reference, and a measurement window
+- **Hypothesis-driven**: each test ties to a hypothesisRef (or the plan explicitly states why it’s exploratory)
+- **Consistency**: distinctive assets are included by default, deviation is justified in the decision log
+- **Versioning**: assets are not overwritten; iterations create new versions (`_v2`, `_v3`, …)
+
+### Distribution system gates (when distribution artifacts exist)
+If a run produces:
+- `outputs/distribution_plan.yaml` or `outputs/repurpose_map.yaml`
+
+Evaluate:
+- **No “spray and pray”**: every channel action maps to a hypothesis and a KPI node
+- **Tracking**: UTMs are present or an explicit “untrackable” note exists (low confidence)
+- **Repurposing discipline**: derived assets are linked to source assets; limits respected
+- **Task handoff**: if the plan includes earned/community/partner actions, the ChangeSet includes `mar21.todo.create` ops with owner and due date
+
+### SEO gates (when SEO artifacts exist)
+If a run produces SEO changes or audits:
+- technical eligibility is addressed first (crawl/index/understand)
+- misconceptions are avoided (no keyword stuffing, no “meta keywords” superstition)
+- changes are tied to evidence (GSC/GA4) and a measurement plan
+
+## Golden runs (fixtures)
+Golden runs are snapshots of a run folder used for regression testing.
+
+Recommended structure (later, during implementation):
+```
+fixtures/
+  golden/
+    weekly_review_minimal/
+      inputs/
+      expected/
+```
+
+Rules:
+- no secrets
+- redact PII
+- keep evidence files small; prefer aggregated tables
+
+Regression checks should verify:
+- schemas validate
+- artifact files exist
+- key JSON outputs contain expected keys
+- report includes required sections
+- ChangeSet ops remain stable in shape (not content)
+
+## Non-goals
+- Tone or style grading (unless explicitly configured in workspace `_cfg/`)
+- “Performance” evals that require live tool accounts (use fixtures for CI)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,0 +1,237 @@
+# mar21 Examples (Concrete Artifacts)
+
+This document shows **end-to-end examples** of the canonical artifacts `mar21` produces and consumes.
+
+## Example 1: `marketing-context.yaml` (minimal but usable)
+```yaml
+apiVersion: mar21/v1
+workspace: acme
+
+company:
+  name: ACME Inc.
+  industry: "B2B SaaS"
+  region: EU
+  languages: [en, de]
+
+businessModel:
+  segment: b2b_saas
+  monetization: subscription
+  pricing:
+    avgContractValue: 1200
+    currency: EUR
+
+goals:
+  primaryKpi: pipeline
+  secondaryKpis: [activation, traffic]
+  kpiTree:
+    pipeline:
+      leading: [mqls, sqls]
+      lagging: [closed_won]
+
+constraints:
+  compliance:
+    gdpr: true
+    sensitiveData: false
+  autonomy:
+    defaultMode: supervised
+    allowlist: []
+  budgets:
+    monthly:
+      total: 8000
+      breakdown:
+        meta_ads: 4000
+        content: 1500
+```
+
+## Example 2: Weekly review run folder
+```
+workspaces/acme/runs/2026-03-11T101530Z_weekly-review/
+  inputs/
+    context.snapshot.yaml
+    request.yaml
+  outputs/
+    plan.md
+    report.md
+    kpi_tree.json
+    deltas.json
+    research_pack.md
+    decision_log.md
+  changeset.yaml
+  logs.jsonl
+  approvals.json
+  run.json
+```
+
+### Example `outputs/research_pack.md` (skeleton with sources)
+```md
+# Research Pack — ACME — 2026-03-11
+
+## Research questions
+- What category narratives are winning in DACH right now?
+- Which competitor positions are crowded vs under-served?
+- What would need to be true for our GTM plan to succeed?
+
+## Findings
+- Competitor positioning clusters around “automation”; “auditability” is underclaimed. [S1]
+- Demand is concentrated in 3 query clusters with rising impressions P28D. [S2]
+
+## Implications
+- Lead with “auditable growth loops” and “human-approved execution”.
+- Prioritize SEO cluster #2 and lifecycle activation improvements.
+
+## Gaps / unknowns
+- Limited evidence on enterprise procurement objections; interview 5 customers.
+
+## Sources
+- [S1] Competitor X landing page — Competitor X — https://example.com — accessed 2026-03-11
+- [S2] (private_doc) ICP interview synthesis — Internal — drive:fileId:abc123 — accessed 2026-03-11
+- [S3] (private_doc) Q1 Win/Loss Notes (PDF) — Internal — drive:fileId:pdf987 — accessed 2026-03-11
+- [S4] (internal_snapshot) Extracted objections from Win/Loss PDF — mar21 — outputs/evidence/gdrive_pdf987.md — accessed 2026-03-11
+- [S5] (internal_snapshot) Google Search Console export (P28D) — ACME property — outputs/evidence/gsc_p28d.json — accessed 2026-03-11
+```
+
+### Example `inputs/request.yaml`
+```yaml
+apiVersion: mar21/request-v1
+workflowId: weekly_review
+workspace: acme
+mode: supervised
+since: P7D
+params:
+  slackChannel: "#growth"
+```
+
+### Example `inputs/request.yaml` (deep research + sparring)
+```yaml
+apiVersion: mar21/request-v1
+workflowId: deep_research_sparring
+workspace: acme
+mode: supervised
+since: P90D
+params:
+  research:
+    questions:
+      - "Which positioning claims are crowded vs underclaimed in DACH?"
+      - "What would have to be true for our pipeline goal to be realistic?"
+    competitorUrls:
+      - "https://example-competitor.com"
+  slackChannel: "#growth"
+```
+
+### Example `outputs/plan.md` (skeleton)
+```md
+# Weekly Review Plan (ACME) — 2026-03-11
+
+## Goal
+Increase pipeline while keeping CAC within guardrails.
+
+## KPI Tree
+- Pipeline → SQLs → MQLs → Sessions → Impressions
+
+## Ranked hypotheses
+1) Meta fatigue in core prospecting ad set is raising CPA.
+2) Landing page friction on pricing page reduces activation.
+3) Demand capture gap: high-impression queries without dedicated pages.
+
+## Tasks (this week)
+- [ ] Pause 2 fatigued ad sets (supervised) — Owner: Ops — ETA: today — Measure: CPA P7D
+- [ ] Draft 2 landing page variants (draft-only) — Owner: Content — ETA: 2 days — Measure: CVR P14D
+- [ ] Create 3 SEO briefs + WP drafts — Owner: Content — ETA: 5 days — Measure: impressions/clicks P28D
+
+## Guardrails
+- No budget increases > 10% without explicit approval
+- No publishing to WordPress without manual review
+```
+
+### Example `outputs/decision_log.md` (skeleton)
+```md
+# Decision Log — ACME — 2026-03-11
+
+## Decisions (this run)
+- We position primarily on “auditable growth loops” rather than “automation”. (evidence: [S1])
+- We prioritize lifecycle activation before increasing top-of-funnel spend. (evidence: GA4 funnel deltas)
+
+## Assumptions
+- ICP is ops-led; sales cycle 30–90 days; pipeline is a meaningful primary KPI.
+- Meta is not saturated; performance can recover with creative refresh + tighter targeting.
+
+## Tradeoffs
+- Slower top-of-funnel scaling in exchange for better activation and CAC guardrails.
+
+## What would change our mind
+- If activation improves but pipeline doesn’t move in 2 cycles, revisit ICP fit and channel mix.
+```
+
+### Example `outputs/report.md` (skeleton)
+```md
+# Weekly Review Report (ACME) — 2026-03-11
+
+## What changed
+- Meta spend +12%, purchases -8% (P7D), CPA +22%
+- GA4 conversions stable; activation down on pricing page
+- GSC: 3 query clusters with high impressions and low CTR
+
+## Why (best current explanation)
+- Creative fatigue in prospecting; placement mix shift to lower-quality inventory
+- Pricing page copy mismatch with ad promise
+
+## What we’ll do
+See `changeset.yaml` ops and the plan tasks.
+
+## Risks & unknowns
+- Attribution mismatch between Meta and GA4
+
+## Next checkpoint
+Next weekly review (P7D), plus daily anomaly guardrails.
+```
+
+### Example `changeset.yaml` (multi-tool)
+```yaml
+apiVersion: mar21/changeset-v1
+runId: 2026-03-11T101530Z_weekly-review
+workspace: acme
+mode: supervised
+
+ops:
+  - id: slack_post_digest
+    tool: slack
+    operation: slack.post_message
+    risk: low
+    requiresApproval: false
+    params:
+      channel: "#growth"
+      messageRef: "outputs/report.md"
+
+  - id: meta_pause_adset_123
+    tool: meta_ads
+    operation: ads.pause_adset
+    risk: medium
+    requiresApproval: true
+    idempotencyKey: "meta_ads:pause_adset:123"
+    params:
+      adsetId: "123"
+      reason: "CPA +22% P7D; fatigue signal; low incremental conversions."
+    expectedImpact:
+      spendDeltaPct: -5
+    evidenceRef:
+      - "outputs/evidence/meta_adset_123_p7d.json"
+    rollbackHint: "Unpause if CPA normalizes after creative refresh."
+
+  - id: wordpress_create_draft_pricing_variant
+    tool: wordpress
+    operation: post.create_draft
+    risk: medium
+    requiresApproval: true
+    params:
+      title: "Pricing page variant A (draft)"
+      contentRef: "outputs/pricing_variant_a.md"
+
+  - id: mar21_memory_update
+    tool: mar21
+    operation: memory.update
+    risk: low
+    requiresApproval: true
+    params:
+      file: "memory/learnings.yaml"
+      patchRef: "outputs/memory_patch.yaml"
+```

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,35 @@
+# mar21 Glossary
+
+**Workspace**  
+A self-contained marketing “instance” for a brand/client: context + secrets + memory + runs.
+
+**Run**  
+The unit of work. A run is a folder containing inputs, outputs, logs, approvals, and a ChangeSet.
+
+**Plan** (`outputs/plan.md`)  
+The executable plan for a run: goal, KPI tree, hypotheses, tasks, measurement, guardrails.
+
+**Report** (`outputs/report.md`)  
+The narrative explanation: what changed, why, what we’ll do, risks, next checkpoint.
+
+**ChangeSet** (`changeset.yaml`)  
+The machine-actionable list of operations to perform (tool-scoped, risk-labeled, approval-aware).
+
+**Skill**  
+A typed, code-first unit of marketing work. It consumes inputs + connector capabilities and produces validated outputs and artifacts.
+
+**Connector**  
+The integration boundary to external tools (auth + API calls + capability declarations + safety).
+
+**Capability**  
+A stable, named operation a connector provides (e.g. `ga4.read.report.run`). Skills reference capabilities.
+
+**Mode**  
+Run-level safety mode: `advisory`, `supervised` (default), or `autonomous` (allowlist only).
+
+**Autopilot**  
+A loop runner that executes scheduled runs (daily/weekly/monthly) while respecting mode and allowlists.
+
+**Memory**  
+Human-readable files that store learnings, winners/losers, exclusions, and durable marketing knowledge that compounds across runs.
+

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,43 @@
+# mar21 Governance
+
+`mar21` is an open-source boilerplate with a stable interface surface. Governance exists to keep interfaces coherent and safe.
+
+## Maintainer model
+- Initially **maintainer-led**: maintainers merge PRs and resolve disputes.
+- As adoption grows, the project may add:
+  - co-maintainers for connectors/domains,
+  - a lightweight RFC process for interface changes (required for breaking changes).
+
+## Interface changes (stable surface)
+Changes to the stable surface (see `docs/VERSIONING.md`) require:
+- updated schemas in `schemas/`
+- updated examples in `examples/`
+- migration notes in the PR description (or a short doc)
+- version bump via `apiVersion` if breaking
+
+## RFC process (when needed)
+For significant changes:
+1) Open an issue titled `RFC: <topic>`
+2) Provide:
+   - motivation
+   - proposed interface changes
+   - backwards-compat story
+   - migration steps
+3) Maintain discussion until decision is documented
+
+## Releases (docs-first now)
+Until code exists:
+- treat doc+schema updates as “release-worthy” if they affect stability
+- keep examples valid and in sync
+
+Once code exists:
+- publish release notes
+- document deprecations and migration windows
+
+## Security and vulnerability reporting
+Report vulnerabilities via **GitHub Security Advisories** (private reporting).
+
+If you discover a security issue:
+- do not open a public issue with exploit details
+- use the repository’s Security tab to submit a private report
+

--- a/docs/MANIFESTO.md
+++ b/docs/MANIFESTO.md
@@ -1,0 +1,64 @@
+# mar21 Manifesto
+
+`mar21` is an **AI-native Marketing Operating System**: a repo-first, skill-driven way to run marketing as a **repeatable, inspectable engine**.
+
+This is a manifesto *and* an implementation stance. The “operating system” is not a metaphor—it's a set of conventions, contracts, and run artifacts that make marketing work **programmable** without making it **opaque**.
+
+## What `mar21` is optimizing for
+- **One-person marketing**: a single operator can go from GTM strategy to day-to-day execution and reporting.
+- **End-to-end value creation**: strategy → planning → instrumentation → acquisition → activation → retention → revenue → learning.
+- **Cross-channel truth**: combine insights from SEO, analytics, ads, CRM, commerce, CMS, and lifecycle into one coherent decision loop.
+- **Self-owned AI competence**: move “AI features” from vendors into *your* system, while still leveraging platform-native AI where it’s useful.
+- **Auditability over vibes**: every run produces artifacts you can read, diff, and trust.
+
+## The shift `mar21` is betting on
+Marketing work is increasingly split into:
+- **strategy and judgment** (human-owned, AI-augmented via deep research + sparring),
+- **execution and operations** (repeatable, tool-driven),
+- **learning loops** (measurement → insight → iteration).
+
+`mar21` moves day-to-day work toward an **agent-driven engine**: not “AI does marketing”, but “marketing becomes a system that can be orchestrated safely”.
+
+AI’s role in `mar21` strategy is explicit:
+- **Deep research**: synthesize market/category signals, competitor positioning, and funnel evidence into a *research pack*.
+- **Sparring**: pressure-test assumptions, propose counter-positions, and surface “what would have to be true” for a plan to work.
+
+The operator remains accountable, and that accountability is captured as artifacts (decisions, assumptions, guardrails).
+
+## Core beliefs (non-negotiables)
+1) **Context is the source of truth.** Marketing work without a durable context file degenerates into prompt roulette.
+2) **Runs are the unit of work.** Every meaningful action happens inside a run with captured inputs, outputs, logs, and approvals.
+3) **Plans must be executable.** A plan is only “done” if it includes measurement, ownership, timeline, and the ChangeSet representing the work.
+4) **Insights must be connected.** SEO ≠ Ads ≠ CRM ≠ Shopify. The value emerges in the *joins*.
+5) **Supervised-by-default is a feature.** Marketing mistakes are expensive; safe autonomy is earned via guardrails, not asserted.
+6) **Your AI is an asset.** Your memory, playbooks, and decision logic compound. They should live in your repo, not in a vendor UI.
+7) **Interfaces beat prompts.** Skills and connectors are contracts. Prompts are implementation details inside those contracts.
+8) **Moving target, stable surface.** The space evolves; `mar21` evolves. But the public interfaces (Context, Skill I/O, ChangeSet) stay stable.
+
+## What “own your AI” means
+Owning your AI does **not** mean “ignore vendor AI”.
+
+It means:
+- Vendor AI can be **a capability** behind a connector.
+- Your system defines **goals, constraints, risk tolerance, and approval policy**.
+- Your repo stores **memory**, **evaluations**, and **decision traces**.
+- Switching providers should not destroy your operating model.
+
+## Anti-patterns (explicitly rejected)
+- **Black-box autopilot**: “trust me” changes without artifacts, approvals, or rollback hints.
+- **Single-tool marketing**: optimizing one platform while ignoring downstream conversion and revenue.
+- **Unversioned context**: strategy lives in heads, decks, or chat logs (and disappears).
+- **Vanity KPI worship**: traffic/CTR without a KPI tree and conversion accounting.
+- **Prompt-first workflows**: untyped inputs/outputs that can’t be tested, replayed, or automated safely.
+- **Permanent firefighting**: no loops, no baselines, no “what changed” narratives.
+
+## How `mar21` evolves (moving target)
+`mar21` treats marketing ops as a product:
+- We start with **one tool per angle** (v1) and add depth iteratively.
+- We keep the system **composable** so new tools and agents can be added without rewriting the core.
+- We prefer **small, safe automations** that earn trust, then expand autonomy.
+
+## Non-goals (for clarity)
+- `mar21` is not a replacement for human strategy; it is a **strategy engine (research + sparring) and execution engine**.
+- `mar21` is not “LLM wrappers everywhere”; it is **interfaces + evidence + control**.
+- `mar21` is not “marketing done for you”; it is **marketing done with leverage**.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,57 @@
+# mar21 Roadmap (Moving Target, Stable Surface)
+
+`mar21` is intentionally a moving target: tools evolve, models evolve, the profession evolves.
+
+What must *not* churn are the **interfaces**:
+- marketing context (`marketing-context.yaml`)
+- skill I/O contracts (`skills/*/skill.yaml`)
+- run artifacts (`runs/<id>/**`)
+- typed ChangeSets (`changeset.yaml`)
+
+This roadmap is organized by maturity levels rather than a rigid timeline.
+
+## Maturity levels
+### L0 — Docs-as-product (now)
+- Manifesto + architecture + specs + workflows
+- Decision-complete contracts for a TypeScript/Node boilerplate
+
+### L1 — Read-only engine
+- CLI skeleton + workspace init wizard
+- Connectors implement read capabilities (GSC, GA4, Meta Ads, HubSpot, Shopify, WordPress, Slack, Klaviyo)
+- Runs produce Plan + Report + ChangeSet suggestions (no writes)
+
+### L2 — Supervised execution
+- `mar21 apply <runId>` applies ChangeSets with interactive approvals
+- Connector dry-run support for write ops
+- Memory updates as ChangeSet ops (supervised)
+
+### L3 — Safe autopilot
+- Built-in loop runner + profiles (daily/weekly/monthly)
+- Workspace allowlist enables limited low-risk autonomous ops
+- Impact budgets (max spend delta, max publish scope, etc.)
+
+### L4 — Verified skills + evaluations
+- Schema validation for every skill output
+- Golden-run fixtures for key workflows
+- Regression checks (output shape + key metrics invariants)
+- Research pack quality gates (sources present, claims attributable, gaps explicit)
+
+## Expansion vectors (after v1)
+### Deeper per-tool support
+- Google Ads connector (search terms, negatives, bids, budgets)
+- Ahrefs connector (keyword explorer, competitor gap)
+- Search Console + GA4 joins (landing page intent → conversion)
+- HubSpot Marketing Hub (emails, workflows) if needed
+- Private docs connector: Google Drive / Docs (priority)
+
+### New channels
+- LinkedIn Ads, TikTok Ads, YouTube, email providers beyond Klaviyo
+
+### Multi-agent “marketing team”
+- SEO agent, Paid agent, Lifecycle agent, CRM agent
+- CMO orchestrator agent delegates, resolves conflicts, enforces budget/risk
+
+### Operational hardening
+- OpenTelemetry traces (optional)
+- CI templates, release workflow for the boilerplate
+- Better secrets UX (keychain-first)

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -1,0 +1,47 @@
+# mar21 Schemas
+
+`mar21` treats schemas as part of the product. Specs are only “real” if they can be validated.
+
+## JSON Schema standard
+- All schemas use **JSON Schema Draft 2020-12**.
+- The schema files live in `schemas/`.
+- YAML artifacts are validated by:
+  1) parsing YAML into JSON,
+  2) validating that JSON instance against the corresponding schema.
+
+## Mapping: files → schemas
+Stable artifacts and their schema:
+- `workspaces/<ws>/marketing-context.yaml` → `schemas/marketing-context.schema.json`
+- `skills/*/*/skill.yaml` → `schemas/skill.schema.json`
+- `runs/<id>/changeset.yaml` → `schemas/changeset.schema.json`
+- `runs/<id>/inputs/request.yaml` → `schemas/request.schema.json`
+- `runs/<id>/run.json` → `schemas/run.schema.json`
+
+Recommended additional schemas:
+- `workspaces/<ws>/profiles/*.yaml` → `schemas/profile.schema.json`
+- `packages/connectors/*/connector.yaml` → `schemas/connector.schema.json`
+- `runs/<id>/outputs/evidence/evidence.json` → `schemas/evidence.schema.json`
+- `runs/<id>/outputs/creative_brief.yaml` → `schemas/creative-brief.schema.json`
+- `runs/<id>/outputs/asset_manifest.yaml` → `schemas/asset-manifest.schema.json`
+- `runs/<id>/outputs/distribution_plan.yaml` → `schemas/distribution-plan.schema.json`
+- `runs/<id>/outputs/repurpose_map.yaml` → `schemas/repurpose-map.schema.json`
+- `workspaces/<ws>/todos.yaml` → `schemas/todos.schema.json`
+
+## `$id` strategy
+Schemas use a stable URN-based `$id` so the identifier doesn’t depend on a hosted domain.
+
+Example:
+- `urn:mar21:schema:marketing-context:v1`
+
+## Validation expectations (docs-only now, code later)
+Future implementation should:
+- validate user-provided files at the CLI boundary (fail fast)
+- validate every skill output before writing artifacts
+- validate ChangeSets before apply
+
+Local validation commands and CI gates will be added during implementation. For now:
+- schemas must remain syntactically valid JSON
+- example instances in `examples/` must remain valid against the schemas
+
+## Examples
+Concrete examples for each schema live in `examples/`.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,91 @@
+# mar21 Security (GDPR-first)
+
+`mar21` treats security and privacy as product requirements, not compliance paperwork.
+
+This document specifies how secrets, PII, approvals, and retention work in the `mar21` operating model.
+
+## Secrets
+- Secrets live in `workspaces/<workspace>/secrets/.env` and are never committed.
+- Prefer **separate credentials** for:
+  - read-only operations (default),
+  - write operations (explicitly enabled),
+  - high-risk operations (kept off by default).
+- OAuth refresh tokens must be stored locally (keychain where available) or encrypted-at-rest in `secrets/`.
+
+## PII and data minimization
+Non-negotiables:
+- **No raw PII in `runs/`** unless the workspace explicitly opts in (and documents why).
+- **No raw PII in logs** (`logs.jsonl`) ever.
+- Pull only what you need for the run scope (aggregation-first).
+
+Examples of data that must be redacted:
+- emails, names, addresses, phone numbers
+- message bodies or free-form notes containing personal data
+- order-level payloads with customer details
+
+## Approvals and audit
+- Every write op is represented as a ChangeSet op (`changeset.yaml`).
+- `approvals.json` records:
+  - operator id (or “local”)
+  - timestamp
+  - op id
+  - decision and optional note
+- Run folders are the audit trail: inputs snapshot + outputs + logs + approvals + changeset.
+
+## Retention defaults
+Defaults (workspace can override):
+- `cache/` snapshots: 30 days
+- `runs/`: retained indefinitely (auditing), unless auto-prune is enabled
+
+If auto-prune is enabled, it must:
+- keep aggregated metrics (if needed) without raw payloads
+- keep ChangeSets and approvals for accountability
+
+## Kill switch
+Every workspace must be able to immediately stop writes:
+- set `constraints.autonomy.defaultMode: advisory`
+- remove allowlist entries
+- revoke write credentials in `secrets/`
+
+## Public vs private sources (research packs)
+`mar21` research is allowed to use both:
+- **public sources** (webpages, public reports), and
+- **private sources** (Notion/Drive/Confluence docs, internal memos, interview notes).
+
+Security requirements for private sources:
+- Treat private docs as **references** first: cite doc ids/refs in `research_pack.md` and avoid copying full content into runs.
+- If excerpts are necessary, store only the minimal excerpt (redacted) in `outputs/evidence/`.
+- Never log private URLs containing tokens; never store them in `runs/`.
+- If private docs contain personal data, default to **summaries** and strip identifiers.
+
+If you plan to ingest private doc systems via connectors, treat them as high-sensitivity connectors:
+- strict scopes
+- aggressive redaction
+- explicit retention policy
+
+### Google Drive specifics (priority)
+- Prefer scopes like Drive **metadata-only** or **readonly** where possible.
+- Store Drive references as `drive:fileId:<id>` in `research_pack.md` sources.
+- If exporting any file type for evidence (Docs/Sheets/Slides/PDFs/images/etc.), store only redacted excerpts in `outputs/evidence/` and reference them from the research pack.
+- Avoid storing full binaries unless explicitly required; if stored, add a retention note and avoid re-distribution.
+
+Default stance:
+- Exporting/downloading Drive files is **allowed by default** in `supervised` mode, but must stay within configured caps (count/size) and follow minimization/redaction rules.
+
+## Supply chain / dependencies (future implementation)
+When code is added:
+- pin dependencies
+- run vulnerability scans in CI
+- keep connector SDK usage behind stable ops (so swapping SDK versions doesn’t change semantics)
+
+## Third-party skills and templates (supply chain)
+If `mar21` supports importing third-party skills/templates:
+- treat them as **code**, not content
+- require review before enabling in autopilot
+- pin versions and record provenance (source + hash)
+- prefer running them in advisory mode first
+
+## Vulnerability reporting
+Report vulnerabilities via **GitHub Security Advisories** (private reporting).
+
+Do not open public issues with exploit details. Use the repository’s Security tab to submit a private report.

--- a/docs/SPECS.md
+++ b/docs/SPECS.md
@@ -1,0 +1,672 @@
+# mar21 Specs (Interfaces + File Formats)
+
+This document defines the **stable surface** of `mar21`. These contracts are designed to be implemented by a CLI agent and to remain stable as tools and models evolve.
+
+Principles:
+- **YAML for human-first config and ops**, JSON for logs/metrics
+- **Typed inputs/outputs everywhere**
+- **Run artifacts are mandatory**
+- **Supervised-by-default**
+- **GDPR-first**
+
+Companion contracts:
+- Schema strategy: `docs/SCHEMAS.md` + `schemas/`
+- CLI contract: `docs/CLI.md`
+- Connector catalogs: `docs/connectors/README.md`
+
+## 1) Workspace model (multi-workspace)
+
+### 1.1 Workspace selection
+The CLI must accept a workspace via:
+- `--workspace <id>` (preferred)
+- `MAR21_WORKSPACE=<id>` (fallback)
+
+Workspace ids are filesystem-safe: `^[a-z0-9][a-z0-9-]{1,31}$`.
+
+### 1.2 CLI surface (minimum, stable verbs)
+The CLI contract is part of the stable surface because it defines how operators trigger runs.
+
+**Global flags**
+- `--workspace <id>`: required unless `MAR21_WORKSPACE` is set
+- `--mode advisory|supervised|autonomous`: overrides context default for the run
+- `--dry-run`: forces “never apply”, still emits a ChangeSet
+- `--since <duration>`: where applicable (e.g. `P7D`, `P28D`)
+
+**Core commands**
+- `mar21 init`: creates a workspace skeleton and a starter context file
+- `mar21 plan <workflow>`: generates a plan for a named workflow (always emits artifacts)
+- `mar21 analyze <scope>`: analysis-only run that still emits ChangeSet suggestions
+- `mar21 report <cadence>`: produces narrative report + machine metrics
+- `mar21 run daily|weekly|monthly`: executes named loops once (emits artifacts)
+- `mar21 autopilot start --profile <name>`: long-running scheduler that emits one run per scheduled execution
+- `mar21 apply <runId>`: applies `changeset.yaml` for a run with interactive approvals
+
+**Optional namespaces (aliases for discoverability)**
+These are CLI aliases that map to workflows and skills; they should not change semantics:
+- `mar21 seo …`
+- `mar21 ads …`
+- `mar21 content …`
+- `mar21 crm …`
+
+### 1.3 Workspace folder layout (canonical)
+```
+workspaces/
+  acme/
+    marketing-context.yaml
+    secrets/
+      .env                 # local-only, never commit
+    _cfg/                  # workspace overrides (update-safe)
+    profiles/              # autopilot profiles (daily/weekly/monthly)
+    todos.yaml             # v1 task store (human work as first-class ops)
+    memory/
+      README.md            # optional: human notes about memory policy
+      learnings.yaml
+      winners.yaml
+      losers.yaml
+      exclusions.yaml
+    cache/
+      snapshots/           # connector response snapshots
+    runs/
+      2026-03-11T101530Z_gTmInAbox/
+        inputs/
+        outputs/
+        logs.jsonl
+        approvals.json
+        changeset.yaml
+        run.json
+```
+
+## 2) Marketing Context schema (YAML)
+
+### 2.1 File
+`workspaces/<workspace>/marketing-context.yaml`
+
+### 2.0 Schema
+Schema: `schemas/marketing-context.schema.json` (`urn:mar21:schema:marketing-context:v1`)
+
+### 2.2 Required fields (v1)
+```yaml
+apiVersion: mar21/v1
+workspace: acme
+
+company:
+  name: ACME Inc.
+  industry: B2B SaaS
+  region: EU
+  languages: [en, de]
+
+businessModel:
+  segment: b2b_saas # one of: b2b_saas, b2c_saas, ecommerce, b2b_industrial, agency, other
+  monetization: subscription # e.g. subscription, one_time, usage_based, razor_razorblade, ads, marketplace, hybrid
+  pricing:
+    avgOrderValue: null
+    avgContractValue: 1200
+    currency: EUR
+
+goToMarket:
+  stage: scale # one of: idea, validation, launch, scale, mature
+  channels:
+    seo:
+      enabled: true
+      primary: true
+    paid_social:
+      enabled: true
+      primary: false
+    lifecycle_email:
+      enabled: true
+      primary: true
+
+goals:
+  primaryKpi: pipeline # e.g. pipeline, revenue, subscriptions, purchases
+  secondaryKpis: [traffic, leads, activation]
+  kpiTree:
+    pipeline:
+      leading: [mqls, sqls]
+      lagging: [closed_won]
+
+constraints:
+  compliance:
+    gdpr: true
+    sensitiveData: false
+  brandVoice:
+    tone: professional
+    doNotSay: ["guaranteed", "best in class"]
+  autonomy:
+    defaultMode: supervised # advisory | supervised | autonomous
+    allowlist:
+      - tool: meta_ads
+        operation: "ads.pause"
+        maxDailyImpact:
+          spendDeltaPct: 10
+  budgets:
+    monthly:
+      total: 8000
+      breakdown:
+        meta_ads: 4000
+        content: 1500
+        tools: 500
+```
+
+### 2.3 Context invariants
+- Context must be **complete enough** to choose KPIs, channels, and constraints without asking ad-hoc questions every run.
+- The orchestrator must snapshot the context into every run (`runs/<id>/inputs/context.snapshot.yaml`).
+- Workspace autonomy allowlist is the **only** way to enable autonomous writes.
+
+### 2.4 Optional strategic fields (recommended for GTM planning)
+These fields are not strictly required for v1 execution, but they materially improve planning quality and consistency.
+
+```yaml
+icp:
+  segments:
+    - name: "Ops-led SaaS"
+      firmographics:
+        companySize: "50-500"
+        region: [DACH, EU]
+      pains: ["manual reporting", "tool sprawl"]
+      triggers: ["new CMO", "budget freeze"]
+
+positioning:
+  category: "AI-native marketing ops"
+  valueProps:
+    - "Run marketing as auditable loops"
+    - "Own your AI competence and memory"
+  proofPoints:
+    - "Weekly review produces Plan/Report/ChangeSet"
+
+measurement:
+  timezone: "Europe/Vienna"
+  utm:
+    sourceOfTruth: "ga4"
+    conventions:
+      utm_source: ["meta", "email", "organic"]
+      utm_medium: ["paid_social", "lifecycle", "seo"]
+
+brand:
+  budgetStrategy:
+    brandBuildingPct: 60
+    activationPct: 40
+  distinctiveAssets:
+    - type: "color"
+      value: "#FF4D00"
+    - type: "tagline"
+      value: "Auditable growth loops"
+  categoryEntryPoints:
+    - "need weekly marketing reporting"
+    - "ad spend waste"
+    - "activation drop on pricing page"
+
+contentGuidelines:
+  peopleFirst: true
+  eeat:
+    requireSourcesForClaims: true
+    requireAboutAuthor: true
+    claimsPolicy:
+      forbid: ["guaranteed outcomes"]
+      requireEvidenceFor: ["benchmarks", "savings claims"]
+  plainLanguage:
+    required: true
+    readingLevelTarget: "general"
+
+creativeSystem:
+  assetIdConvention: "<channel>_<format>_<angle>_<yyyy-mm>_<vN>"
+  defaultTestWindow: P7D
+  fatigueSignals:
+    meta_ads:
+      watch:
+        - "cpa_up"
+        - "ctr_down"
+        - "frequency_up"
+      thresholds:
+        cpaDeltaPct: 20
+        ctrDeltaPct: -15
+        frequency: 2.5
+
+distributionSystem:
+  utmRequired: true
+  earnedChannelsEnabled: true
+  taskHandoff:
+    enabled: true
+    defaultOwner: "operator"
+```
+
+## 3) Skill contract (code-first, typed I/O)
+
+### 3.1 Skill manifest
+Skills live under `skills/` and include a machine-readable manifest:
+
+`skills/<domain>/<skill>/skill.yaml`
+
+Schema: `schemas/skill.schema.json` (`urn:mar21:schema:skill:v1`)
+
+```yaml
+apiVersion: mar21/skill-v1
+id: seo.gsc_opportunity_clusters
+domain: seo
+description: "Turn GSC query/page data into prioritized opportunity clusters."
+
+inputs:
+  schema:
+    type: object
+    required: [dateRange, minImpressions]
+    properties:
+      dateRange: { type: string, description: "e.g. P28D" }
+      minImpressions: { type: number, minimum: 0 }
+
+outputs:
+  schema:
+    type: object
+    required: [clusters]
+    properties:
+      clusters:
+        type: array
+        items:
+          type: object
+          required: [name, pages, queries, opportunityScore]
+          properties:
+            name: { type: string }
+            pages: { type: array, items: { type: string } }
+            queries: { type: array, items: { type: string } }
+            opportunityScore: { type: number }
+
+usesConnectors:
+  - gsc.read.search_analytics
+
+risk:
+  level: low # none|low|medium|high
+  writes: false
+
+artifacts:
+  produces:
+    - outputs/opportunity_clusters.json
+    - outputs/opportunity_clusters.md
+
+idempotency:
+  strategy: "pure" # pure|snapshot_based|tool_write
+```
+
+### 3.2 Skill execution rules
+- Skills must be runnable with only their typed inputs + connector access + workspace memory.
+- If an LLM is used, its prompt is an implementation detail; output must still validate against `outputs.schema`.
+- Skills must write artifacts only inside the active run folder.
+
+## 4) Connector contract (tool integrations)
+
+### 4.1 Connector capabilities
+Each connector must declare:
+- `toolId` (e.g. `ga4`, `gsc`, `meta_ads`, `hubspot`, `shopify`, `wordpress`, `slack`, `klaviyo`)
+- Supported operations with:
+  - `read` vs `write`
+  - risk level (`low|medium|high`)
+  - dry-run support
+- rate-limit strategy
+
+For exhaustive per-tool capability catalogs, see `docs/connectors/README.md`.
+
+### 4.2 Auth boundary (local-first env + OAuth)
+- Secrets live in `workspaces/<workspace>/secrets/.env` and are not committed.
+- OAuth tokens must be stored locally (keychain where available) or encrypted-at-rest file within `secrets/`.
+- Connectors must never log raw secrets; runs may log *redacted* config.
+
+Schema (recommended): `schemas/connector.schema.json` (`urn:mar21:schema:connector:v1`)
+
+## 5) ChangeSet format (Typed Ops YAML)
+
+### 5.1 File
+`runs/<id>/changeset.yaml`
+
+Schema: `schemas/changeset.schema.json` (`urn:mar21:schema:changeset:v1`)
+
+### 5.2 Structure
+```yaml
+apiVersion: mar21/changeset-v1
+runId: 2026-03-11T101530Z_weekly-review
+workspace: acme
+mode: supervised # advisory|supervised|autonomous
+
+ops:
+  - id: meta_pause_adset_01
+    tool: meta_ads
+    operation: ads.pause_adset
+    risk: medium
+    requiresApproval: true
+    idempotencyKey: "meta_ads:pause_adset:12345"
+    params:
+      adsetId: "12345"
+      reason: "Spend up, purchases down; fatigue signal; CPA > threshold."
+    expectedImpact:
+      spendDeltaPct: -8
+      cpaDeltaPct: -10
+    evidenceRef:
+      - "outputs/evidence/meta_adset_12345_p7d.json"
+    rollbackHint: "Unpause ad set 12345 if CPA recovers or attribution changes."
+
+  - id: slack_post_digest_01
+    tool: slack
+    operation: slack.post_message
+    risk: low
+    requiresApproval: false
+    params:
+      channel: "#growth"
+      messageRef: "outputs/weekly_digest.md"
+    evidenceRef:
+      - "outputs/report.md"
+```
+
+### 5.3 Semantics
+- A ChangeSet is **the** machine-actionable representation of work.
+- Applying a ChangeSet is a separate step that records approvals and results.
+- `requiresApproval` must be true unless:
+  - operation is `risk: low`, **and**
+  - workspace allowlist permits it, **and**
+  - mode is `autonomous`.
+
+### 5.4 `mar21` internal ops (v1)
+Not all work is a tool API call. `mar21` defines internal ops to track human work and repo-owned knowledge:
+- `mar21.todo.create|update|close` (task system; see `docs/TASKS.md`)
+- `mar21.memory.update` (memory updates; see section 8)
+
+## 6) Safety + approvals model
+
+### 6.1 Modes
+- `advisory`: never applies writes; always produces suggestions in ChangeSet
+- `supervised` (default): may apply writes only after interactive approvals
+- `autonomous`: may apply allowlisted low-risk writes without a prompt
+
+### 6.3 Read operations and sensitive sources
+Reads do not require ChangeSet approvals, but they still have privacy risk.
+
+Default policy:
+- Read capabilities are allowed by default in all modes.
+- “Sensitive reads” (e.g. private-doc exports/downloads) are allowed by default in `supervised` mode **with caps**:
+  - only fetch what is needed for the run scope,
+  - prefer metadata-first,
+  - store excerpts (redacted) rather than full files,
+  - enforce `maxDownloads` and `maxFileSizeMB` limits from the request/profile (or sensible defaults).
+
+If the run needs to exceed caps, the CLI should prompt for confirmation and record the decision in `logs.jsonl` (without leaking doc URLs).
+
+### 6.2 Approval UX (CLI)
+When applying, the CLI must:
+- show each op (tool, operation, risk, reason, rollback hint)
+- prompt `approve? (y/n)` for required approvals
+- write `approvals.json` with:
+  - who approved (operator id)
+  - timestamp
+  - op id
+  - decision + optional note
+
+## 7) Run artifacts + observability
+
+### 7.1 Run folder
+Every run must produce:
+- `outputs/plan.md`
+- `outputs/report.md`
+- `changeset.yaml`
+- `logs.jsonl` (structured)
+- `run.json` (run metadata)
+
+Recommended (machine-readable) additions:
+- `outputs/plan.yaml` (task list, owners, timelines, measurements)
+- `outputs/report.json` (key metrics + deltas for downstream tooling)
+- `outputs/evidence/` (files referenced by report/changeset, e.g. aggregated tables)
+- `outputs/research_pack.md` (deep research synthesis with **sources**; mainly for strategy/planning workflows)
+- `outputs/decision_log.md` (human-owned decisions, assumptions, tradeoffs)
+Creative/distribution (when relevant):
+- `outputs/creative_brief.yaml` (schema: `urn:mar21:schema:creative-brief:v1`)
+- `outputs/asset_manifest.yaml` (schema: `urn:mar21:schema:asset-manifest:v1`)
+- `outputs/creative_matrix.yaml` (recommended; schema optional initially)
+- `outputs/distribution_plan.yaml` (schema: `urn:mar21:schema:distribution-plan:v1`)
+- `outputs/repurpose_map.yaml` (schema: `urn:mar21:schema:repurpose-map:v1`)
+
+Example:
+```
+runs/<runId>/
+  inputs/
+    context.snapshot.yaml
+    request.yaml
+  outputs/
+    plan.md
+    report.md
+    kpi_tree.json
+    plan.yaml
+    report.json
+    evidence/
+  changeset.yaml
+  logs.jsonl
+  approvals.json
+  run.json
+```
+
+### 7.2 `logs.jsonl` event shape (minimum)
+Each line is a JSON object:
+```json
+{"ts":"2026-03-11T10:15:30Z","level":"info","event":"connector.fetch","tool":"ga4","op":"ga4.report","durationMs":842}
+```
+
+### 7.2.1 `run.json` metadata (minimum)
+`run.json` must include enough to replay and to reason about safety:
+```json
+{
+  "apiVersion": "mar21/run-v1",
+  "runId": "2026-03-11T101530Z_weekly-review",
+  "workspace": "acme",
+  "workflowId": "weekly_review",
+  "mode": "supervised",
+  "since": "P7D",
+  "startedAt": "2026-03-11T10:15:30Z",
+  "finishedAt": "2026-03-11T10:17:12Z",
+  "connectorsUsed": ["ga4", "gsc", "meta_ads", "shopify", "hubspot", "klaviyo", "slack"],
+  "writesAttempted": false
+}
+```
+
+Schema: `schemas/run.schema.json` (`urn:mar21:schema:run:v1`)
+
+### 7.3 Plan/Report minimum templates (opinionated)
+To keep runs comparable across time and across workspaces, these documents must follow a minimum structure.
+
+`outputs/plan.md` must include:
+- Goal (single sentence)
+- KPI tree (what moves what)
+- Hypotheses (ranked)
+- Tasks (with owners, ETA, measurement)
+- Assumptions & open questions
+- Guardrails (what we won’t do)
+
+`outputs/report.md` must include:
+- What changed (deltas + evidence refs)
+- Why (most likely causes)
+- What we did / will do (linked to ChangeSet ops)
+- Risks & unknowns
+- Next checkpoint (date/cadence)
+
+`outputs/research_pack.md` must include (when produced):
+- Research questions (what we’re trying to learn)
+- Findings (each major claim annotated with source ids like `[S1]`)
+- Implications for strategy (what changes in positioning/channel mix/creative)
+- Gaps/unknowns (what we still don’t know)
+- Sources section with:
+  - stable source ids (`S1`, `S2`, …)
+  - source type, title, publisher/owner, location reference (URL or private ref), and accessed date
+
+Recommended citation format:
+```md
+## Findings
+- Category demand is seasonal in DACH; Q4 spikes correlate with budget cycles. [S1]
+- Competitor X positions on “automation” but lacks “auditability” claims. [S2]
+
+## Sources
+- [S1] (public_url) Title — Publisher — https://… — accessed 2026-03-11
+- [S2] (private_doc) Memo: ICP Interviews — Internal — drive:docid:abc123 — accessed 2026-03-11
+- [S3] (internal_snapshot) GSC export (P28D) — ACME property — outputs/evidence/gsc_p28d.json — accessed 2026-03-11
+```
+
+### 7.3.1 Source types (required)
+`mar21` supports both **public** and **private** sources. A research pack must label each source as one of:
+- `public_url`: a public webpage or public document URL
+- `private_doc`: a private document reference (Drive/Notion/Confluence/etc.) that may not be shareable publicly
+- `internal_snapshot`: an internal run artifact (e.g. connector snapshot in `outputs/evidence/`)
+- `interview_note`: human notes or transcripts (must be PII-safe; default is summaries only)
+
+### 7.3.2 Private-doc handling (GDPR-first)
+When citing or using private docs:
+- Prefer referencing by **document id/ref** rather than copying full contents into run logs.
+- If excerpts are needed, keep them short and avoid PII; store excerpts in `outputs/evidence/` with redaction.
+- Never put private doc URLs/tokens in logs; store access configuration in `secrets/` only.
+- The run must record **what was accessed** (doc refs) and **when**, but not store secret-bearing URLs.
+
+Recommended private doc ref formats:
+- Google Drive: `drive:fileId:<id>`
+- Notion: `notion:page:<id>`
+- Confluence: `confluence:page:<id>`
+
+### 7.3.3 Evidence extraction for arbitrary file types (Drive priority)
+When private sources include arbitrary file types (Docs/Sheets/Slides/PDFs/images/etc.), the default approach is:
+1) cite the original as `private_doc` (by ref),
+2) extract only the minimal needed evidence into `outputs/evidence/`,
+3) cite the extracted artifact as `internal_snapshot`.
+
+Recommended evidence file naming:
+- `outputs/evidence/gdrive_<fileId>.<ext>`
+- `outputs/evidence/<tool>_<descriptor>_<window>.<ext>` (e.g. `ga4_funnel_p7d.json`)
+
+Recommended evidence manifest (optional but useful):
+`outputs/evidence/evidence.json`
+```json
+[
+  {
+    "id": "E1",
+    "sourceRef": "drive:fileId:abc123",
+    "derivedFrom": "private_doc",
+    "path": "outputs/evidence/gdrive_abc123.md",
+    "contentType": "text/markdown",
+    "redacted": true,
+    "sha256": "…",
+    "notes": "Extracted only the section about ICP objections; names removed."
+  }
+]
+```
+
+Schema: `schemas/evidence.schema.json` (`urn:mar21:schema:evidence:v1`)
+
+## 8) Marketing memory (files)
+
+### 8.1 Goals
+Memory must:
+- compound learnings across runs
+- be human-readable and reviewable
+- be safe to edit manually
+
+### 8.2 Canonical files (suggested)
+`workspaces/<workspace>/memory/`:
+- `learnings.yaml`: durable “what we learned”
+- `winners.yaml`: headlines/angles/audiences/keywords that work (with evidence refs)
+- `losers.yaml`: what failed (and why)
+- `exclusions.yaml`: negative keywords, blocked audiences, forbidden claims
+
+### 8.3 Update rules
+- Skills may propose memory updates as ChangeSet ops (tool: `mar21`, operation: `memory.update`).
+- Memory updates are supervised by default, because they influence future decisions.
+
+## 9) Connector manifest (recommended, for capability discovery)
+While connectors can be code-only, `mar21` strongly recommends a small manifest so skills can declare requirements and the CLI can validate “what writes are even possible”.
+
+`packages/connectors/<tool>/connector.yaml`:
+```yaml
+apiVersion: mar21/connector-v1
+toolId: ga4
+displayName: "Google Analytics 4"
+auth:
+  type: oauth
+  scopes:
+    - "https://www.googleapis.com/auth/analytics.readonly"
+capabilities:
+  - id: ga4.read.report
+    risk: low
+    writes: false
+    dryRun: true
+  - id: ga4.write.annotation
+    risk: medium
+    writes: true
+    dryRun: true
+rateLimits:
+  strategy: "token_bucket"
+  requestsPerMinute: 60
+```
+
+## 10) GDPR-first requirements (non-optional)
+- **Data minimization**: connectors fetch only fields needed for the current run scope.
+- **Redaction**: logs must not contain emails, names, raw message content, or raw order PII.
+- **Retention**: `cache/` has a documented retention (default 30 days); `runs/` are kept unless the workspace opts into an auto-prune policy.
+- **Separation**: secrets are never stored in `runs/` and are never committed.
+
+## 11) Workflow requests and autopilot profiles (recommended)
+Workflows are triggered by the CLI, but the run must persist “what exactly was requested” in a stable shape.
+
+### 11.1 `inputs/request.yaml`
+`runs/<runId>/inputs/request.yaml`:
+```yaml
+apiVersion: mar21/request-v1
+workflowId: weekly_review
+workspace: acme
+mode: supervised # advisory|supervised|autonomous
+since: P7D
+params:
+  currency: EUR
+  minSpend: 50
+  slackChannel: "#growth"
+  research:
+    questions:
+      - "What changed in the category narrative in DACH over the last 90 days?"
+      - "Which ICP objections are most likely blocking activation?"
+    competitorUrls:
+      - "https://example-competitor.com"
+    sources:
+      drive:
+        fileIds: ["abc123", "pdf987"] # optional; preferred for deterministic pulls
+        folderIds: []                 # optional
+        query: null                   # optional Drive query string
+        limits:
+          maxDownloads: 10
+          maxFileSizeMB: 25
+```
+
+Schema: `schemas/request.schema.json` (`urn:mar21:schema:request:v1`)
+
+### 11.2 Autopilot profiles
+Profiles define what `mar21 run daily|weekly|monthly` *means* for a workspace.
+
+Recommended location:
+- `workspaces/<workspace>/profiles/daily.yaml`
+- `workspaces/<workspace>/profiles/weekly.yaml`
+- `workspaces/<workspace>/profiles/monthly.yaml`
+
+Example `profiles/weekly.yaml`:
+```yaml
+apiVersion: mar21/profile-v1
+id: weekly
+steps:
+  - workflowId: weekly_review
+    mode: supervised
+    since: P7D
+  - workflowId: meta_cleanup
+    mode: supervised
+    since: P7D
+  - workflowId: demand_capture
+    mode: supervised
+    since: P28D
+```
+
+Schema: `schemas/profile.schema.json` (`urn:mar21:schema:profile:v1`)
+
+## 12) Task system (v1)
+Task store:
+- `workspaces/<workspace>/todos.yaml`
+
+Schema:
+- `schemas/todos.schema.json` (`urn:mar21:schema:todos:v1`)
+
+Task mutations:
+- only via ChangeSet ops (`mar21.todo.*`), supervised by default
+
+See `docs/TASKS.md` for the full contract and examples.

--- a/docs/STRUCTURE_PATTERNS.md
+++ b/docs/STRUCTURE_PATTERNS.md
@@ -1,0 +1,86 @@
+# mar21 Structure Patterns (What We Standardize)
+
+This document captures repo-structure patterns `mar21` intentionally adopts to keep the boilerplate:
+- updateable,
+- override-friendly,
+- safe to operate,
+- and easy to extend.
+
+It does not depend on any single upstream project; these are common patterns in modern agent/tool frameworks.
+
+## 1) Stable surface vs implementation
+We separate:
+- **stable surface**: file formats + capability ids + run artifacts
+- **implementation**: heuristics, SDKs, prompts, internal orchestration
+
+This lets the repo evolve without breaking operators.
+
+## 2) Overlay configuration (`_cfg/`)
+Each workspace gets an override layer:
+- `workspaces/<ws>/_cfg/`
+
+Purpose:
+- keep local customization and policies separate from core defaults
+- make upstream updates easier (fewer merge conflicts)
+
+## 3) Catalog + manifests
+We treat “what exists” as data:
+- skills have manifests (`skills/*/*/skill.yaml`)
+- connectors have manifests (recommended) (`packages/connectors/*/connector.yaml`)
+- schemas are first-class (`schemas/`)
+
+This enables discovery, validation, and tooling.
+
+## 4) Runs as immutable artifacts
+The run folder is the audit trail:
+- inputs snapshot
+- evidence
+- plan/report
+- changeset
+- approvals
+- structured logs
+
+Runs are meant to be replayable and reviewable.
+
+## 5) Modules/packs mindset (future code organization)
+Even in a monorepo, `mar21` should feel modular:
+- core orchestration in `packages/core`
+- UI/CLI boundary in `packages/cli`
+- each connector in `packages/connectors/<tool>`
+- skills in `skills/`
+
+This keeps tool integrations isolated and replaceable.
+
+## 6) “Core” vs “packs” (optional distribution pattern)
+As the implementation grows, `mar21` can separate:
+- a **core** set of skills/workflows/templates that everyone gets, and
+- optional **packs** (expansions) for specific industries, motions, or tool stacks.
+
+This enables:
+- smaller installs (one-person marketing should not require a giant context window),
+- clearer governance (“core” stays stable; packs iterate faster),
+- easier sharing of best-practice playbooks.
+
+Suggested structure (in the implementation repo):
+```
+packs/
+  core/
+  ecommerce/
+  b2b_saas/
+  agency/
+```
+
+## 7) Bundles (optional “copy/paste” distribution)
+Some operators will run `mar21` via chat-first tools rather than a CLI.
+For those cases, a “bundle export” pattern can exist:
+- produce single-file bundles of selected skills/workflows/templates suitable for upload.
+
+Suggested structure:
+```
+dist/
+  skills/
+  workflows/
+  teams/        # grouped bundles (e.g., SEO+Content+Lifecycle)
+```
+
+These bundles are a distribution convenience and must never replace the stable surface artifacts (Context, ChangeSet, Runs).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,129 @@
+# mar21 Tasks (Human Work as First-Class Ops)
+
+Marketing execution is not only API calls. A lot of value creation is still human work:
+- PR pitches
+- partner outreach
+- creative production (design/video)
+- stakeholder reviews
+- instrumentation fixes
+
+`mar21` treats this work as **trackable**, **reviewable**, and **loop-closable** by encoding it as tasks and referencing it from ChangeSets and run artifacts.
+
+## Goals
+- Make GTM and distribution plans executable end-to-end (not just “recommendations”).
+- Keep human work in the same audit trail as tool ops (Plan/Report/ChangeSet/Runs).
+- Enable autopilot to generate tasks safely (supervised), and allow operators to close the loop.
+
+## Storage: `todos.yaml` (v1)
+In v1, tasks live in a workspace-local file:
+- `workspaces/<workspace>/todos.yaml`
+
+Schema:
+- `schemas/todos.schema.json` (`urn:mar21:schema:todos:v1`)
+
+This file is the single source of truth for task status.
+
+## Task model
+Each task must include:
+- `taskId` (stable id)
+- `title` (short)
+- `description` (optional; should not contain PII)
+- `status`: `open|in_progress|blocked|done|canceled`
+- `owner` (string, usually “operator” for one-person marketing)
+- `dueDate` (ISO date, optional)
+- `priority`: `p0|p1|p2|p3`
+- `tags` (e.g. `pr`, `partner`, `creative`, `instrumentation`)
+- `createdAt` (ISO datetime)
+- provenance:
+  - `createdBy.runId`
+  - `createdBy.opId` (ChangeSet op that created it)
+- `evidenceRef` (optional list of run-relative evidence paths)
+
+### Task id format
+Tasks should be filesystem-safe and sortable:
+
+`T-<YYYYMMDD>-<NNN>`
+
+Example:
+- `T-20260312-001`
+
+If a runner cannot guarantee sequencing, it may generate:
+- `T-<YYYYMMDD>-<HHMMSS>-<rand>`
+
+## ChangeSet ops for tasks (v1)
+Tasks are created/updated/closed via ChangeSet ops with `tool: mar21`.
+
+### `mar21.todo.create`
+Creates a new task in `todos.yaml`.
+
+Example op:
+```yaml
+- id: todo_pr_pitch_01
+  tool: mar21
+  operation: mar21.todo.create
+  risk: low
+  requiresApproval: true
+  params:
+    task:
+      title: "Pitch 5 category reporters (auditability angle)"
+      description: "Use research pack findings [S1]/[S2]. Draft email. Track replies."
+      owner: "operator"
+      dueDate: "2026-03-15"
+      priority: p1
+      tags: ["pr", "distribution"]
+      evidenceRef:
+        - "outputs/research_pack.md"
+```
+
+### `mar21.todo.update`
+Updates fields on an existing task (e.g. owner, dueDate, status, notes).
+
+Example:
+```yaml
+- id: todo_update_01
+  tool: mar21
+  operation: mar21.todo.update
+  risk: low
+  requiresApproval: true
+  params:
+    taskId: "T-20260312-001"
+    patch:
+      status: in_progress
+```
+
+### `mar21.todo.close`
+Closes a task as `done` or `canceled` with an optional outcome note.
+
+Example:
+```yaml
+- id: todo_close_01
+  tool: mar21
+  operation: mar21.todo.close
+  risk: low
+  requiresApproval: true
+  params:
+    taskId: "T-20260312-001"
+    status: done
+    outcome: "2 replies, 1 interview scheduled. Added learning to memory."
+    evidenceRef:
+      - "outputs/evidence/pr_outreach_log.csv"
+```
+
+## How tasks appear in run artifacts
+When tasks are created/updated/closed, the run should:
+- reference tasks in `outputs/plan.md` (“Tasks (this week)” section)
+- include task ids in `outputs/report.md` (“What we did” / “What we’ll do”)
+- include ChangeSet ops for task mutations
+
+## Privacy (GDPR-first)
+- Avoid PII in task descriptions and outcome notes.
+- Store contact lists or sensitive outreach details only as redacted evidence, or keep them outside `runs/`.
+
+## Future (connectors)
+Later, tasks can be backed by external systems:
+- Linear/Jira/Asana/Trello
+
+When that happens:
+- `todos.yaml` can remain a local cache, or
+- the external system becomes the source of truth and `todos.yaml` becomes derived.
+

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,94 @@
+# mar21 Versioning & Compatibility
+
+This document defines how `mar21` evolves **without breaking users**.
+
+## The stable surface (must be compatible)
+These interfaces are considered the **stable surface**:
+- Marketing context: `workspaces/<ws>/marketing-context.yaml`
+- Skill manifests and their typed I/O: `skills/*/*/skill.yaml`
+- Connector capability ids (e.g. `ga4.read.report.run`)
+- ChangeSets: `runs/<id>/changeset.yaml`
+- Run artifact contract and layout: `runs/<id>/**` (required files + minimum templates)
+
+Everything else is allowed to iterate more freely (internal implementation, prompts, SDK usage, heuristics).
+
+## `apiVersion` rules
+Every artifact that is part of the stable surface must include an `apiVersion` string.
+
+Naming:
+- Context: `mar21/v1`
+- Skill manifest: `mar21/skill-v1`
+- Connector manifest: `mar21/connector-v1`
+- ChangeSet: `mar21/changeset-v1`
+- Request: `mar21/request-v1`
+- Run metadata: `mar21/run-v1`
+- Autopilot profile: `mar21/profile-v1`
+
+Rules:
+- **Compatible changes** keep the same `apiVersion`.
+- **Breaking changes** require a new `apiVersion` (e.g. `mar21/changeset-v2`).
+- Do not overload meanings: if semantics change, version changes.
+
+## What is backwards-compatible vs breaking?
+
+### Marketing context (`mar21/v1`)
+Backwards-compatible:
+- add a new **optional** field (with a default behavior)
+- add a new enum value *only if* it is treated as “unknown/other” safely by old runners
+
+Breaking:
+- rename/remove a field
+- change a field type (string → object, number → string)
+- change semantics of a field (e.g. interpreting budget units differently)
+- make a previously optional field required
+
+### Skill manifests (`mar21/skill-v1`)
+Backwards-compatible:
+- add optional metadata fields (e.g. `tags`, `examples`)
+- expand `usesConnectors` with additional *optional* capabilities
+
+Breaking:
+- change `id` format/meaning
+- change output schema in a way that invalidates old consumers
+
+### ChangeSets (`mar21/changeset-v1`)
+Backwards-compatible:
+- add optional fields in ops (`expectedImpact`, `evidenceRef`)
+- add a new op type if the apply engine treats unknown ops as “unsupported” and refuses safely
+
+Breaking:
+- change op semantics (e.g. risk levels, approval behavior)
+- change required fields for ops
+- change how idempotency keys are interpreted
+
+### Connector capability ids
+Backwards-compatible:
+- add new capabilities
+- deprecate a capability (keep it working for the deprecation window)
+
+Breaking:
+- rename a capability id
+- change the semantics of a capability id (same id does something different)
+
+## Deprecation policy
+- Deprecations must be announced in:
+  - release notes (once code exists), and
+  - docs (`docs/ROADMAP.md` and the relevant spec).
+- A deprecated field/capability must remain supported for **at least 2 minor releases** (once releases exist).
+- Deprecations must include:
+  - “replacement” guidance,
+  - migration steps,
+  - examples of before/after.
+
+## How to introduce a v2
+When a breaking change is required:
+1) Add new schema + docs for the v2 artifact (`schemas/*-v2*.json`).
+2) Keep v1 support during the deprecation window (dual-read / dual-write where feasible).
+3) Provide a migration guide and tooling notes (even if manual at first).
+4) Only then mark v1 as deprecated.
+
+## Release discipline (docs-first)
+Until implementation exists, treat doc changes like API changes:
+- If you change a required field or semantics in specs, update `apiVersion` accordingly.
+- Keep example artifacts in `examples/` in sync with schemas.
+

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,320 @@
+# mar21 Workflows (Operator Playbook)
+
+All workflows follow the same contract:
+- **Trigger → Inputs → Connectors → Skills → Artifacts → Optional writes**
+- Every run produces **Plan + Report + ChangeSet** (even when “no changes”).
+- Writes are **supervised-by-default** unless allowlisted.
+
+Evidence-based defaults and gates are defined in `docs/BEST_PRACTICES.md` and enforced via `docs/EVALS.md`.
+
+v1 first-class integrations (one per angle):
+- SEO: Google Search Console (`gsc`)
+- Analytics: GA4 (`ga4`)
+- Ads: Meta Ads (`meta_ads`)
+- CRM: HubSpot (`hubspot`)
+- Commerce: Shopify (`shopify`)
+- CMS: WordPress (`wordpress`)
+- Comms: Slack (`slack`)
+- Email: Klaviyo (`klaviyo`)
+
+## Typical CLI usage
+Workflows can be invoked via generic verbs or (optionally) via namespaces:
+
+```bash
+mar21 plan gtm_in_a_box --workspace acme
+mar21 report weekly_review --workspace acme
+mar21 run daily --workspace acme
+
+# Optional namespace aliases
+mar21 seo run demand_capture --workspace acme
+mar21 ads plan meta_cleanup --workspace acme
+mar21 crm report lead_to_revenue_hygiene --workspace acme
+```
+
+## 0) Deep Research + Sparring
+**Workflow ID:** `deep_research_sparring`  
+**Trigger:** before GTM planning, for monthly GTM refresh, or when performance drifts and you need new hypotheses.  
+**Command:** `mar21 plan deep_research_sparring --workspace <id> --since <duration>`
+
+**Goal**
+Create an evidence-backed **research pack** and a structured **sparring** output that pressure-tests the current strategy and produces measurable next steps.
+
+**Inputs**
+- `marketing-context.yaml` (ICP, positioning, goals, constraints)
+- optional: explicit research questions (otherwise derived from context + current KPIs)
+- optional: competitor list / URLs
+
+**Connectors (v1, optional but recommended)**
+- GSC (organic demand signals)
+- GA4 (funnel + conversion evidence)
+- Meta Ads (paid social performance context)
+- Shopify / HubSpot / Klaviyo (revenue/lifecycle evidence if relevant)
+- Google Drive (`gdrive`) for private strategy docs and attachments (all file types)
+
+**Skills (examples)**
+- `strategy.research_questions_derive`
+- `strategy.deep_research_pack` (must output `research_pack.md` with sources)
+- `strategy.sparring_positioning_and_risks` (thesis/antithesis, falsification tests)
+- `strategy.hypothesis_backlog_generate` (ranked hypotheses with evidence + measurement)
+
+**Artifacts**
+- `outputs/research_pack.md`: findings with `[S1]…` citations + Sources section
+- `outputs/decision_log.md`: decisions, assumptions, tradeoffs, “what changes our mind”
+- `outputs/plan.md`: the executable next steps (experiments, owners, measurement, timelines)
+- `outputs/report.md`: summary + key implications + what changed vs last research run
+- `changeset.yaml`: usually `mar21.todo.create`, `mar21.memory.update`, Slack digest (no tool writes by default)
+
+**Optional writes**
+- Slack digest (low risk; can be auto)
+- Memory updates (supervised-by-default)
+
+**How this feeds other workflows**
+- `gtm_in_a_box` should include the latest `research_pack.md` and link decisions to it.
+- `weekly_review` should reference research-derived hypotheses when explaining “why” and “what we’ll do”.
+- Monthly `run monthly` should refresh research + sparring before budget reallocation.
+
+## 1) GTM in a Box (Strategy Sprint)
+**Workflow ID:** `gtm_in_a_box`
+**Trigger:** new product, new market, new motion, or “we don’t have a real plan”.
+**Command:** `mar21 plan gtm_in_a_box --workspace <id>`
+
+**Inputs**
+- `marketing-context.yaml` (must include model + monetization + goals + constraints)
+- optional: existing positioning docs, competitor list
+
+**Connectors (v1)**
+- none required; optional reads if available (GA4, GSC)
+
+**Skills (examples)**
+- `strategy.deep_research_pack`
+- `strategy.sparring_positioning_and_risks`
+- `strategy.kpi_tree_define`
+- `strategy.channel_mix_recommend`
+- `strategy.timeline_budget_plan`
+- `strategy.measurement_instrumentation_plan`
+
+**Artifacts**
+- `outputs/plan.md`: 2–6 week timeline, owners, deliverables, experiments, measurement
+- `outputs/report.md`: rationale + assumptions + risks
+- `outputs/research_pack.md`: synthesis + competitor/category notes, **with sources** (`[S1]`… + Sources section)
+- `outputs/decision_log.md`: what we decided, what we deferred, what would change our mind
+- `changeset.yaml`: “setup tasks” (usually `mar21.todo.create` style ops, advisory by default)
+
+**Optional writes**
+- none by default (setup is mostly human work); may post Slack summary.
+
+## 2) Weekly Growth Operating Review
+**Workflow ID:** `weekly_review`
+**Trigger:** weekly cadence (exec-ready view + operator action list).
+**Command:** `mar21 report weekly_review --workspace <id>`
+
+**Connectors**
+- GA4, GSC, Meta Ads, Shopify, HubSpot, Klaviyo (+ Slack for broadcast)
+
+**Skills (examples)**
+- `analytics.kpi_tree_compute`
+- `analytics.week_over_week_deltas`
+- `ads.meta_efficiency_audit`
+- `seo.gsc_opportunity_clusters`
+- `lifecycle.klaviyo_flow_health`
+- `commerce.shopify_cohort_signals`
+
+**Artifacts**
+- `outputs/plan.md`: next-week priorities + experiments
+- `outputs/report.md`: “what changed, why, what we’ll do”
+- `changeset.yaml`: cleanup + low-risk fixes (supervised)
+
+**Optional writes (supervised)**
+- Pause obvious waste (bounded by allowlist)
+- Post Slack digest
+
+## 3) Daily Anomaly Guardrail (Autopilot loop)
+**Workflow ID:** `daily_anomaly_guardrail`
+**Trigger:** daily (or intra-day) health checks.
+**Command:** `mar21 run daily --workspace <id>` (or `mar21 autopilot start --profile daily --workspace <id>`)
+
+**Connectors**
+- GA4, Meta Ads, Shopify, HubSpot (+ Slack)
+
+**Skills**
+- `monitoring.baseline_build_or_load`
+- `monitoring.detect_anomalies`
+- `monitoring.generate_investigation_steps`
+
+**Artifacts**
+- `outputs/plan.md`: investigation checklist
+- `outputs/report.md`: anomaly summary + suspected causes
+- `changeset.yaml`: suggestions (advisory) or bounded mitigations (supervised)
+
+**Optional writes**
+- Slack alerts (low risk, may be auto)
+- “Stop the bleeding” actions only if allowlisted
+
+## 4) Meta Ads Waste & Structure Cleanup
+**Workflow ID:** `meta_cleanup`
+**Trigger:** weekly (or when spend spikes / performance drops).
+**Command:** `mar21 ads plan meta_cleanup --workspace <id>` (or `mar21 plan meta_cleanup --workspace <id>`)
+
+**Connectors**
+- Meta Ads (+ GA4 for downstream signals)
+
+**Skills**
+- `ads.meta_searchless_waste_scan`
+- `ads.meta_placement_breakdown`
+- `ads.meta_creative_fatigue_detect`
+- `ads.meta_budget_reallocation_plan`
+
+**Artifacts**
+- Plan + report with thresholds and evidence refs
+- ChangeSet with pause/rename/reallocate ops (supervised)
+
+## 4.1) Creative Pipeline (Weekly)
+**Workflow ID:** `creative_pipeline_weekly`  
+**Trigger:** weekly cadence to keep creative intentional and refreshed.  
+**Command:** `mar21 plan creative_pipeline_weekly --workspace <id> --since P28D`
+
+**Connectors (v1)**
+- Meta Ads (insights for fatigue)
+- GA4 (downstream conversion context)
+- WordPress/Klaviyo (destination and lifecycle context; optional)
+
+**Skills (examples)**
+- `ads.meta_creative_fatigue_detect`
+- `creative.brief_generate`
+- `creative.matrix_generate`
+- `creative.asset_manifest_update`
+- `content.eeat_review`
+- `copy.plain_language_check`
+
+**Artifacts**
+- `outputs/creative_brief.md` + `outputs/creative_brief.yaml`
+- `outputs/creative_matrix.yaml`
+- `outputs/asset_manifest.yaml`
+- `outputs/creative_fatigue.json`
+- `changeset.yaml`: pause/rotate ops (supervised) + create draft tasks/assets
+
+## 5) SEO Demand Capture Engine
+**Workflow ID:** `demand_capture`
+**Trigger:** weekly content pipeline + monthly theme planning.
+**Command:** `mar21 seo run demand_capture --workspace <id>` (or `mar21 run weekly --workspace <id>`)
+
+**Connectors**
+- GSC (+ WordPress draft API)
+
+**Skills**
+- `seo.gsc_query_intent_map`
+- `seo.gsc_opportunity_clusters`
+- `content.brief_generate`
+- `content.wordpress_draft_create`
+- `content.eeat_review` (people-first + trust fit-for-purpose)
+- `copy.plain_language_check` (clarity + scannability)
+- `seo.snippet_quality_check` (titles/snippets aligned to intent)
+- `seo.internal_linking_plan`
+
+**Artifacts**
+- Plan: editorial calendar + briefs + internal linking tasks
+- Report: why these topics, expected impact, measurement
+- ChangeSet: create WP drafts (draft-only) + internal link TODOs
+
+## 6) Lifecycle Revenue Loop (Klaviyo × Shopify)
+**Workflow ID:** `lifecycle_revenue_loop`
+**Trigger:** weekly retention + monthly lifecycle refresh.
+**Command:** `mar21 run weekly --workspace <id>` (or `mar21 plan lifecycle_revenue_loop --workspace <id>`)
+
+**Connectors**
+- Klaviyo, Shopify (+ GA4 optional)
+
+**Skills**
+- `lifecycle.flow_funnel_audit`
+- `lifecycle.segment_opportunity_scan`
+- `lifecycle.subjectline_test_plan`
+- `lifecycle.draft_updates`
+- `copy.plain_language_check` (clarity + CTA)
+
+**Artifacts**
+- Plan: tests + rollout + measurement
+- Report: drop-offs and segments
+- ChangeSet: draft updates; optionally push to draft state (supervised)
+
+## 7) Lead-to-Revenue Hygiene (HubSpot)
+**Workflow ID:** `lead_to_revenue_hygiene`
+**Trigger:** weekly pipeline quality and SLA checks.
+**Command:** `mar21 crm report lead_to_revenue_hygiene --workspace <id>` (or `mar21 report lead_to_revenue_hygiene --workspace <id>`)
+
+**Connectors**
+- HubSpot (+ Slack for escalations)
+
+**Skills**
+- `crm.lifecycle_stage_consistency_audit`
+- `crm.pipeline_leak_detection`
+- `crm.nurture_gap_plan`
+
+**Artifacts**
+- Plan: fixes and ownership
+- Report: where leads die + what to change
+- ChangeSet: property fixes / workflow suggestions (supervised)
+
+## 8) Landing Page Conversion Iteration (WordPress × GA4)
+**Workflow ID:** `landing_page_iteration`
+**Trigger:** weekly conversion work; after campaign launches.
+**Command:** `mar21 plan landing_page_iteration --workspace <id>`
+
+**Connectors**
+- WordPress, GA4 (+ Meta Ads context)
+
+**Skills**
+- `cro.funnel_dropoff_analysis`
+- `cro.hypothesis_generate`
+- `cro.variant_copy_draft`
+- `content.eeat_review` (trust checks for claims and tone)
+- `copy.plain_language_check` (comprehension-first)
+- `cro.measurement_plan`
+
+**Artifacts**
+- Plan: hypotheses + variants + QA + measurement window
+- Report: evidence + expected impact
+- ChangeSet: WP draft updates (supervised)
+
+## 9) Distribution Weekly (Owned/Earned/Paid)
+**Workflow ID:** `distribution_weekly`  
+**Trigger:** weekly cadence to ship and measure distribution, not only drafts.  
+**Command:** `mar21 plan distribution_weekly --workspace <id> --since P7D`
+
+**Connectors (v1)**
+- WordPress (owned)
+- Klaviyo (owned)
+- Meta Ads (paid context; optional)
+- Slack (operator broadcast)
+
+**Skills (examples)**
+- `distribution.plan_generate`
+- `distribution.calendar_generate`
+- `distribution.repurpose_map_generate`
+- `copy.plain_language_check`
+
+**Artifacts**
+- `outputs/distribution_plan.md` + `outputs/distribution_plan.yaml`
+- `outputs/distribution_calendar.md`
+- `outputs/repurpose_map.yaml`
+- `outputs/measurement_plan.md`
+- `changeset.yaml`: draft/schedule ops where possible + `mar21.todo.create` for PR/community/partners
+
+## Autopilot loops (daily / weekly / monthly)
+
+### Daily (`mar21 run daily`)
+- Anomaly guardrails (traffic/spend/revenue/leads)
+- “Inbox zero” triage: generate investigation steps + Slack summary
+
+### Weekly (`mar21 run weekly`)
+- Growth Operating Review
+- Meta Ads cleanup (bounded)
+- SEO opportunity clusters + briefs
+- Lifecycle flow health + test plan
+- Creative system pipeline (briefs + matrix + fatigue)
+- Distribution weekly (calendar + repurpose map)
+
+### Monthly (`mar21 run monthly`)
+- GTM refresh (positioning, ICP, channels)
+- Deep research refresh + sparring (update `research_pack.md` + decisions)
+- Budget reallocation strategy + forecast
+- Measurement audit (events, UTMs, attribution assumptions)

--- a/docs/connectors/README.md
+++ b/docs/connectors/README.md
@@ -1,0 +1,36 @@
+# mar21 Connector Catalogs
+
+This folder contains the per-tool **capability catalogs** for v1. Each connector doc lists:
+- auth method + minimal scopes
+- env vars
+- capability ids (stable)
+- risk levels, dry-run behavior
+- limits (rate, paging, lookback)
+- data minimization and PII handling rules
+
+## Naming conventions
+Capability ids follow:
+
+`<tool>.<read|write>.<resource>.<verb>`
+
+Examples:
+- `ga4.read.report.run`
+- `meta_ads.write.adset.pause`
+- `gdrive.read.files.download`
+
+Risk levels:
+- `low`: reversible, bounded, low likelihood of harm
+- `medium`: changes live systems or handles sensitive data, but bounded/reversible
+- `high`: irreversible or large monetary/brand risk
+
+## v1 connector catalogs
+- `gsc.md`
+- `ga4.md`
+- `meta_ads.md`
+- `hubspot.md`
+- `shopify.md`
+- `wordpress.md`
+- `slack.md`
+- `klaviyo.md`
+- `gdrive.md` (priority private docs; all file types)
+

--- a/docs/connectors/ga4.md
+++ b/docs/connectors/ga4.md
@@ -1,0 +1,29 @@
+# Google Analytics 4 (`ga4`) — Connector Catalog (v1)
+
+## Auth
+- Type: OAuth
+- Recommended scope (read-only): `https://www.googleapis.com/auth/analytics.readonly`
+
+Env vars (suggested):
+- `MAR21_GA4_CLIENT_ID`
+- `MAR21_GA4_CLIENT_SECRET`
+- `MAR21_GA4_REFRESH_TOKEN`
+
+## Data minimization / PII
+- Prefer aggregated reports; avoid pulling user-level identifiers.
+- Respect consent mode; reports must include “Measurement Reality” disclaimers.
+
+## Capabilities (v1)
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `ga4.read.report.run` | read | low | yes | `propertyId`, `since`, `dimensions[]`, `metrics[]` | paging depends on report; rate-limited by API |
+| `ga4.read.funnel.summary` | read | low | yes | `propertyId`, `since`, `funnelDefinition` | derived from reports |
+
+### Optional writes (still supervised)
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `ga4.write.annotation.create` | write | medium | yes | `propertyId`, `timestamp`, `note` | treat as supervised-only |
+
+## Explicitly later
+- Audience management, config writes
+

--- a/docs/connectors/gdrive.md
+++ b/docs/connectors/gdrive.md
@@ -1,0 +1,50 @@
+# Google Drive (`gdrive`) — Connector Catalog (v1, all file types)
+
+`gdrive` is the priority private-doc connector for `mar21`. It supports reading **all file types** with a default policy:
+- allowed by default in `supervised` mode
+- metadata-first, capped, and excerpt-based evidence
+
+## Auth
+- Type: OAuth
+- Recommended scopes (read):
+  - `https://www.googleapis.com/auth/drive.metadata.readonly` (search + metadata)
+  - `https://www.googleapis.com/auth/drive.readonly` (downloads/exports)
+
+Env vars (suggested):
+- `MAR21_GDRIVE_CLIENT_ID`
+- `MAR21_GDRIVE_CLIENT_SECRET`
+- `MAR21_GDRIVE_REFRESH_TOKEN`
+
+## Data minimization / PII
+Non-negotiables:
+- cite by `drive:fileId:<id>` in `outputs/research_pack.md`
+- store **excerpts** in `outputs/evidence/` by default, not full documents
+- redact names/emails and other PII in excerpts
+- never log tokenized private URLs
+
+## Capability catalog (v1)
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `gdrive.read.files.search` | read | low | yes | `query` or `folderId`, `limit` | cap results (default 50) |
+| `gdrive.read.files.get_metadata` | read | low | yes | `fileId` | - |
+| `gdrive.read.files.export` | read | low/medium | yes | `fileId`, `mimeType` | cap size; Sheets/Slides exports can be large |
+| `gdrive.read.files.download` | read | medium | yes | `fileId` | cap downloads and max file size |
+
+## Recommended export formats (by type)
+- Google Docs → Markdown or plain text
+- Google Sheets → CSV
+- Google Slides → PDF
+- PDFs → text extraction via a skill (redacted)
+- Images → optional OCR via a skill (redacted)
+
+## Default caps (recommended)
+Unless overridden via `inputs/request.yaml`:
+- `maxDownloads`: 10
+- `maxFileSizeMB`: 25
+
+If caps are exceeded, the CLI must prompt for confirmation and record the decision (no private URLs).
+
+## Explicitly later
+- Creating/modifying Drive files (high risk)
+- Auto-sharing or permission changes (out of scope)
+

--- a/docs/connectors/gsc.md
+++ b/docs/connectors/gsc.md
@@ -1,0 +1,27 @@
+# Google Search Console (`gsc`) — Connector Catalog (v1)
+
+## Auth
+- Type: OAuth
+- Recommended scope (read-only): `https://www.googleapis.com/auth/webmasters.readonly`
+
+Env vars (suggested):
+- `MAR21_GSC_CLIENT_ID`
+- `MAR21_GSC_CLIENT_SECRET`
+- `MAR21_GSC_REFRESH_TOKEN`
+
+## Data minimization / PII
+- Prefer aggregated search analytics; avoid exporting raw URL lists beyond what is needed for a run.
+- Store exports as aggregated tables in `outputs/evidence/`.
+
+## Capabilities (v1)
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `gsc.read.search_analytics.query` | read | low | yes | `siteUrl`, `since`, `dimensions[]` | paging by row limit; max lookback depends on property |
+
+## Supported in v1
+- Search analytics by query/page/country/device, used for opportunity clustering and demand capture.
+
+## Explicitly later
+- Index coverage, sitemaps, manual actions
+- Write actions (generally avoided)
+

--- a/docs/connectors/hubspot.md
+++ b/docs/connectors/hubspot.md
@@ -1,0 +1,30 @@
+# HubSpot (`hubspot`) — Connector Catalog (v1)
+
+## Auth
+- Type: Private App token
+
+Env vars (suggested):
+- `MAR21_HUBSPOT_PRIVATE_APP_TOKEN`
+
+## Data minimization / PII
+- Default to aggregated lifecycle metrics.
+- Avoid exporting raw contacts; if required, pull only minimal fields and redact.
+
+## Capabilities (v1)
+### Reads
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `hubspot.read.deals.list` | read | low | yes | `since`, `properties[]` | paging |
+| `hubspot.read.contacts.list` | read | medium | yes | `since`, `properties[]` | treat as medium due to PII risk |
+| `hubspot.read.lifecycle.metrics` | read | low | yes | `since` | aggregated |
+
+### Writes (supervised)
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `hubspot.write.property.update` | write | medium | yes | `objectType`, `objectId`, `patch` | bounded changes |
+| `hubspot.write.task.create` | write | low/medium | yes | `assignee`, `dueAt`, `note` | avoid PII in notes |
+
+## Explicitly later
+- Workflow automation changes
+- Bulk contact updates without strict scoping
+

--- a/docs/connectors/klaviyo.md
+++ b/docs/connectors/klaviyo.md
@@ -1,0 +1,28 @@
+# Klaviyo (`klaviyo`) — Connector Catalog (v1)
+
+## Auth
+- Type: Private API key
+
+Env vars (suggested):
+- `MAR21_KLAVIYO_PRIVATE_API_KEY`
+
+## Data minimization / PII
+- Prefer aggregated metrics.
+- Avoid pulling raw subscriber profiles unless strictly necessary.
+
+## Capabilities (v1)
+### Reads
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `klaviyo.read.flows.list` | read | low | yes | `since` | paging |
+| `klaviyo.read.campaigns.list` | read | low | yes | `since` | paging |
+| `klaviyo.read.metrics.aggregate` | read | low | yes | `since`, `metricIds[]` | rate-limited |
+
+### Writes (draft-only, supervised)
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `klaviyo.write.draft.update` | write | medium | yes | `draftId`, `patchRef` | drafts only |
+
+## Explicitly later
+- Sending/scheduling campaigns (high risk)
+

--- a/docs/connectors/meta_ads.md
+++ b/docs/connectors/meta_ads.md
@@ -1,0 +1,33 @@
+# Meta Ads (`meta_ads`) — Connector Catalog (v1)
+
+## Auth
+- Type: OAuth access token
+
+Env vars (suggested):
+- `MAR21_META_ADS_ACCESS_TOKEN`
+- `MAR21_META_ADS_ACCOUNT_ID`
+
+## Data minimization / PII
+- Do not pull user-level data.
+- Prefer insights aggregations by entity (campaign/adset/ad).
+- Store only aggregated evidence in `outputs/evidence/`.
+
+## Capabilities (v1)
+### Reads
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `meta_ads.read.insights.by_campaign` | read | low | yes | `accountId`, `since`, `fields[]` | paging; API rate limits |
+| `meta_ads.read.insights.by_adset` | read | low | yes | `accountId`, `since`, `fields[]` | paging; API rate limits |
+| `meta_ads.read.insights.by_ad` | read | low | yes | `accountId`, `since`, `fields[]` | paging; API rate limits |
+
+### Writes (supervised-by-default)
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `meta_ads.write.adset.pause` | write | medium | yes | `adsetId`, `reason` | bounded by allowlist/impact caps |
+| `meta_ads.write.campaign.pause` | write | medium/high | yes | `campaignId`, `reason` | high when spend impact is large |
+| `meta_ads.write.budget.update` | write | high | yes | `entityId`, `amount`, `currency` | must be capped and approved |
+
+## Explicitly later
+- Creative uploads and publishing
+- Broad structural changes without a simulation step
+

--- a/docs/connectors/shopify.md
+++ b/docs/connectors/shopify.md
@@ -1,0 +1,22 @@
+# Shopify (`shopify`) — Connector Catalog (v1)
+
+## Auth
+- Type: Admin API access token
+
+Env vars (suggested):
+- `MAR21_SHOPIFY_ACCESS_TOKEN`
+- `MAR21_SHOPIFY_STORE_DOMAIN`
+
+## Data minimization / PII
+- Prefer order aggregations and cohort summaries.
+- Do not store customer PII in runs; default to summary rows.
+
+## Capabilities (v1)
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `shopify.read.orders.list` | read | medium | yes | `since`, `fields[]` | treat as medium (PII risk), paging |
+| `shopify.read.revenue.summary` | read | low | yes | `since` | derived from orders (aggregated) |
+
+## Writes (v1)
+- None by default (commerce writes are treated as high-risk)
+

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -1,0 +1,20 @@
+# Slack (`slack`) — Connector Catalog (v1)
+
+## Auth
+- Type: Bot token
+
+Env vars (suggested):
+- `MAR21_SLACK_BOT_TOKEN`
+
+## Data minimization / PII
+- Avoid posting personal data; prefer aggregated and redacted summaries.
+
+## Capabilities (v1)
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `slack.write.message.post` | write | low | yes | `channel`, `messageRef` | rate-limited by Slack API |
+| `slack.write.thread.reply` | write | low | yes | `channel`, `threadTs`, `messageRef` | rate-limited |
+
+## Reads (v1)
+- none required
+

--- a/docs/connectors/wordpress.md
+++ b/docs/connectors/wordpress.md
@@ -1,0 +1,29 @@
+# WordPress (`wordpress`) — Connector Catalog (v1)
+
+## Auth
+- Type: Application password (or OAuth, later)
+
+Env vars (suggested):
+- `MAR21_WORDPRESS_BASE_URL`
+- `MAR21_WORDPRESS_APP_PASSWORD`
+
+## Data minimization / PII
+- Do not fetch private user data.
+- Treat content edits as medium/high risk based on publish state.
+
+## Capabilities (v1)
+### Reads
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `wordpress.read.post.list` | read | low | yes | `since`, `status` | paging |
+| `wordpress.read.page.list` | read | low | yes | `since`, `status` | paging |
+
+### Writes (draft-only, supervised)
+| Capability id | Read/Write | Risk | Dry-run | Required params | Limits |
+|---|---|---:|---:|---|---|
+| `wordpress.write.post.create_draft` | write | medium | yes | `title`, `contentRef` | drafts only |
+| `wordpress.write.post.update_draft` | write | medium | yes | `postId`, `contentRef` | drafts only |
+
+## Explicitly later
+- Publishing or updating live pages (high risk)
+

--- a/examples/asset-manifest.yaml
+++ b/examples/asset-manifest.yaml
@@ -1,0 +1,17 @@
+apiVersion: mar21/asset-manifest-v1
+runId: 2026-03-12T090000Z_meta_cleanup
+workspace: acme
+
+assets:
+  - assetId: meta_video_auditability_2026-03_v1
+    channel: meta_ads
+    format: video
+    status: planned
+    briefRef: outputs/creative_brief.yaml
+    hypothesisRef: HYP-001
+    tracking:
+      utm_campaign: prospecting_auditability
+    measurement:
+      primaryMetric: cpa
+      window: P7D
+

--- a/examples/changeset.yaml
+++ b/examples/changeset.yaml
@@ -1,0 +1,30 @@
+apiVersion: mar21/changeset-v1
+runId: 2026-03-11T101530Z_weekly_review
+workspace: acme
+mode: supervised
+
+ops:
+  - id: slack_post_digest
+    tool: slack
+    operation: slack.write.message.post
+    risk: low
+    requiresApproval: false
+    params:
+      channel: "#growth"
+      messageRef: "outputs/report.md"
+
+  - id: meta_pause_adset_123
+    tool: meta_ads
+    operation: meta_ads.write.adset.pause
+    risk: medium
+    requiresApproval: true
+    idempotencyKey: "meta_ads:pause_adset:123"
+    params:
+      adsetId: "123"
+      reason: "CPA +22% P7D; fatigue signal."
+    expectedImpact:
+      spendDeltaPct: -5
+    evidenceRef:
+      - "outputs/evidence/meta_adset_123_p7d.json"
+    rollbackHint: "Unpause if CPA normalizes after creative refresh."
+

--- a/examples/connector.yaml
+++ b/examples/connector.yaml
@@ -1,0 +1,21 @@
+apiVersion: mar21/connector-v1
+toolId: gdrive
+displayName: "Google Drive"
+auth:
+  type: oauth
+  scopes:
+    - "https://www.googleapis.com/auth/drive.metadata.readonly"
+    - "https://www.googleapis.com/auth/drive.readonly"
+capabilities:
+  - id: gdrive.read.files.search
+    risk: low
+    writes: false
+    dryRun: true
+  - id: gdrive.read.files.export
+    risk: medium
+    writes: false
+    dryRun: true
+rateLimits:
+  strategy: token_bucket
+  requestsPerMinute: 60
+

--- a/examples/creative-brief.yaml
+++ b/examples/creative-brief.yaml
@@ -1,0 +1,38 @@
+apiVersion: mar21/creative-brief-v1
+runId: 2026-03-12T090000Z_meta_cleanup
+workspace: acme
+
+goal:
+  kpiNode: conversions
+  successMetric: cpa
+  target: "CPA <= 45 EUR (P7D)"
+
+audience:
+  segmentRef: "icp.segments[0]"
+  pains: ["manual reporting", "tool sprawl"]
+  objections: ["too complex", "no time"]
+
+offer:
+  promise: "Weekly review that ships actions, not dashboards."
+  proof: ["case study", "demo video"]
+  cta: "Book a 15‑min audit"
+
+message:
+  angle: "auditable growth loops"
+  supportPoints:
+    - "Plan/Report/ChangeSet every week"
+    - "Supervised-by-default"
+  doNotSay: ["guaranteed outcomes"]
+
+constraints:
+  brandAssetsRequired: true
+  eeatRequired: true
+  plainLanguageRequired: true
+
+tracking:
+  utm:
+    required: true
+    utm_source: "meta"
+    utm_medium: "paid_social"
+    utm_campaign: "prospecting_auditability"
+

--- a/examples/distribution-plan.yaml
+++ b/examples/distribution-plan.yaml
@@ -1,0 +1,40 @@
+apiVersion: mar21/distribution-plan-v1
+runId: 2026-03-12T090000Z_distribution_weekly
+workspace: acme
+since: P7D
+
+goal:
+  kpiNode: pipeline
+  target: "SQLs +10% (P28D)"
+
+sourceAssets:
+  - assetId: wp_post_category-entry-point_2026-03_v1
+    type: pillar
+    status: draft
+
+channels:
+  owned:
+    - id: wordpress
+      cadence: weekly
+    - id: email
+      provider: klaviyo
+      cadence: weekly
+  paid:
+    - id: meta_ads
+      cadence: ongoing
+  earned:
+    - id: pr
+      cadence: weekly
+    - id: community
+      cadence: weekly
+    - id: partnerships
+      cadence: monthly
+
+repurposingPolicy:
+  maxDerivedAssetsPerSource: 6
+  requireDistinctiveAssets: true
+  requirePlainLanguage: true
+
+tracking:
+  utmRequired: true
+

--- a/examples/evidence.json
+++ b/examples/evidence.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "E1",
+    "sourceRef": "drive:fileId:pdf987",
+    "derivedFrom": "private_doc",
+    "path": "outputs/evidence/gdrive_pdf987.md",
+    "contentType": "text/markdown",
+    "redacted": true,
+    "sha256": "00000000000000000000000000000000",
+    "notes": "Extracted only the section about ICP objections; names removed."
+  }
+]
+

--- a/examples/marketing-context.yaml
+++ b/examples/marketing-context.yaml
@@ -1,0 +1,50 @@
+apiVersion: mar21/v1
+workspace: acme
+
+company:
+  name: ACME Inc.
+  industry: "B2B SaaS"
+  region: EU
+  languages: [en, de]
+
+businessModel:
+  segment: b2b_saas
+  monetization: subscription
+  pricing:
+    avgOrderValue: null
+    avgContractValue: 1200
+    currency: EUR
+
+goToMarket:
+  stage: scale
+  channels:
+    seo: { enabled: true, primary: true }
+    paid_social: { enabled: true, primary: false }
+    lifecycle_email: { enabled: true, primary: true }
+
+goals:
+  primaryKpi: pipeline
+  secondaryKpis: [traffic, leads, activation]
+  kpiTree:
+    pipeline:
+      leading: [mqls, sqls]
+      lagging: [closed_won]
+
+constraints:
+  compliance:
+    gdpr: true
+    sensitiveData: false
+  brandVoice:
+    tone: professional
+    doNotSay: ["guaranteed", "best in class"]
+  autonomy:
+    defaultMode: supervised
+    allowlist: []
+  budgets:
+    monthly:
+      total: 8000
+      breakdown:
+        meta_ads: 4000
+        content: 1500
+        tools: 500
+

--- a/examples/profile.yaml
+++ b/examples/profile.yaml
@@ -1,0 +1,10 @@
+apiVersion: mar21/profile-v1
+id: weekly
+steps:
+  - workflowId: weekly_review
+    mode: supervised
+    since: P7D
+  - workflowId: deep_research_sparring
+    mode: supervised
+    since: P90D
+

--- a/examples/repurpose-map.yaml
+++ b/examples/repurpose-map.yaml
@@ -1,0 +1,17 @@
+apiVersion: mar21/repurpose-map-v1
+runId: 2026-03-12T090000Z_distribution_weekly
+workspace: acme
+
+maps:
+  - sourceAssetId: wp_post_category-entry-point_2026-03_v1
+    derived:
+      - assetId: meta_static_auditability_2026-03_v1
+        channel: meta_ads
+        format: static
+      - assetId: email_subject_activation_fix_2026-03_v1
+        channel: email
+        format: subject_line
+      - assetId: slack_announcement_entry_point_2026-03_v1
+        channel: slack
+        format: message
+

--- a/examples/request.yaml
+++ b/examples/request.yaml
@@ -1,0 +1,20 @@
+apiVersion: mar21/request-v1
+workflowId: deep_research_sparring
+workspace: acme
+mode: supervised
+since: P90D
+params:
+  research:
+    questions:
+      - "Which positioning claims are crowded vs underclaimed in DACH?"
+      - "What would have to be true for our pipeline goal to be realistic?"
+    competitorUrls:
+      - "https://example-competitor.com"
+    sources:
+      drive:
+        fileIds: ["abc123", "pdf987"]
+        limits:
+          maxDownloads: 10
+          maxFileSizeMB: 25
+  slackChannel: "#growth"
+

--- a/examples/run.json
+++ b/examples/run.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": "mar21/run-v1",
+  "runId": "2026-03-11T101530Z_weekly_review",
+  "workspace": "acme",
+  "workflowId": "weekly_review",
+  "mode": "supervised",
+  "since": "P7D",
+  "startedAt": "2026-03-11T10:15:30Z",
+  "finishedAt": "2026-03-11T10:17:12Z",
+  "connectorsUsed": ["ga4", "gsc", "meta_ads", "shopify", "hubspot", "klaviyo", "slack", "gdrive"],
+  "writesAttempted": false
+}
+

--- a/examples/skill.yaml
+++ b/examples/skill.yaml
@@ -1,0 +1,41 @@
+apiVersion: mar21/skill-v1
+id: strategy.deep_research_pack
+domain: strategy
+description: "Create a research pack with attributable findings and sources."
+
+inputs:
+  schema:
+    type: object
+    required: [since]
+    properties:
+      since: { type: string, description: "ISO 8601 duration, e.g. P90D" }
+
+outputs:
+  schema:
+    type: object
+    required: [sources, findings]
+    properties:
+      sources:
+        type: array
+        items: { type: string }
+      findings:
+        type: array
+        items: { type: string }
+
+usesConnectors:
+  - gdrive.read.files.search
+  - gdrive.read.files.export
+  - ga4.read.report.run
+  - gsc.read.search_analytics.query
+
+risk:
+  level: low
+  writes: false
+
+artifacts:
+  produces:
+    - outputs/research_pack.md
+
+idempotency:
+  strategy: snapshot_based
+

--- a/examples/todos.yaml
+++ b/examples/todos.yaml
@@ -1,0 +1,19 @@
+apiVersion: mar21/todos-v1
+workspace: acme
+
+tasks:
+  - taskId: "T-20260312-001"
+    title: "Pitch 5 category reporters (auditability angle)"
+    description: "Use research pack findings [S1]/[S2]. Draft email. Track replies."
+    status: open
+    owner: operator
+    dueDate: "2026-03-15"
+    priority: p1
+    tags: ["pr", "distribution"]
+    createdAt: "2026-03-12T09:10:00Z"
+    createdBy:
+      runId: "2026-03-12T090000Z_distribution_weekly"
+      opId: "todo_pr_pitch_01"
+    evidenceRef:
+      - "outputs/research_pack.md"
+

--- a/schemas/asset-manifest.schema.json
+++ b/schemas/asset-manifest.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:asset-manifest:v1",
+  "title": "mar21 Asset Manifest (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "runId", "workspace", "assets"],
+  "properties": {
+    "apiVersion": { "const": "mar21/asset-manifest-v1" },
+    "runId": { "type": "string", "minLength": 10 },
+    "workspace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{1,31}$" },
+    "assets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["assetId", "channel", "format", "status"],
+        "properties": {
+          "assetId": { "type": "string", "pattern": "^[a-z0-9_\\-]+$" },
+          "channel": { "type": "string", "minLength": 1 },
+          "format": { "type": "string", "minLength": 1 },
+          "status": { "enum": ["planned", "draft", "active", "paused", "retired"] },
+          "briefRef": { "type": "string" },
+          "hypothesisRef": { "type": "string" },
+          "files": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+          "tracking": { "type": "object", "additionalProperties": true },
+          "measurement": { "type": "object", "additionalProperties": true }
+        }
+      }
+    }
+  }
+}
+

--- a/schemas/changeset.schema.json
+++ b/schemas/changeset.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:changeset:v1",
+  "title": "mar21 ChangeSet (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "runId", "workspace", "mode", "ops"],
+  "properties": {
+    "apiVersion": { "const": "mar21/changeset-v1" },
+    "runId": { "type": "string", "minLength": 10 },
+    "workspace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{1,31}$" },
+    "mode": { "enum": ["advisory", "supervised", "autonomous"] },
+    "ops": {
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "tool", "operation", "risk", "requiresApproval", "params"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "tool": { "type": "string", "minLength": 1 },
+          "operation": { "type": "string", "minLength": 1 },
+          "risk": { "enum": ["low", "medium", "high"] },
+          "requiresApproval": { "type": "boolean" },
+          "idempotencyKey": { "type": "string" },
+          "params": { "type": "object", "additionalProperties": true },
+          "expectedImpact": { "type": "object", "additionalProperties": true },
+          "evidenceRef": { "type": "array", "items": { "type": "string" } },
+          "rollbackHint": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+

--- a/schemas/connector.schema.json
+++ b/schemas/connector.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:connector:v1",
+  "title": "mar21 Connector Manifest (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "toolId", "displayName", "auth", "capabilities"],
+  "properties": {
+    "apiVersion": { "const": "mar21/connector-v1" },
+    "toolId": { "type": "string", "minLength": 1 },
+    "displayName": { "type": "string", "minLength": 1 },
+    "auth": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "minLength": 1 },
+        "scopes": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "risk", "writes", "dryRun"],
+        "properties": {
+          "id": { "type": "string", "minLength": 3 },
+          "risk": { "enum": ["low", "medium", "high"] },
+          "writes": { "type": "boolean" },
+          "dryRun": { "type": "boolean" }
+        }
+      }
+    },
+    "rateLimits": { "type": "object", "additionalProperties": true }
+  }
+}
+

--- a/schemas/creative-brief.schema.json
+++ b/schemas/creative-brief.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:creative-brief:v1",
+  "title": "mar21 Creative Brief (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "runId", "workspace", "goal", "audience", "offer", "message", "constraints", "tracking"],
+  "properties": {
+    "apiVersion": { "const": "mar21/creative-brief-v1" },
+    "runId": { "type": "string", "minLength": 10 },
+    "workspace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{1,31}$" },
+    "goal": { "type": "object", "additionalProperties": true },
+    "audience": { "type": "object", "additionalProperties": true },
+    "offer": { "type": "object", "additionalProperties": true },
+    "message": { "type": "object", "additionalProperties": true },
+    "constraints": { "type": "object", "additionalProperties": true },
+    "tracking": { "type": "object", "additionalProperties": true }
+  }
+}
+

--- a/schemas/distribution-plan.schema.json
+++ b/schemas/distribution-plan.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:distribution-plan:v1",
+  "title": "mar21 Distribution Plan (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "runId", "workspace", "goal", "channels", "tracking"],
+  "properties": {
+    "apiVersion": { "const": "mar21/distribution-plan-v1" },
+    "runId": { "type": "string", "minLength": 10 },
+    "workspace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{1,31}$" },
+    "since": { "type": "string" },
+    "goal": { "type": "object", "additionalProperties": true },
+    "sourceAssets": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "channels": { "type": "object", "additionalProperties": true },
+    "repurposingPolicy": { "type": "object", "additionalProperties": true },
+    "tracking": { "type": "object", "additionalProperties": true }
+  }
+}
+

--- a/schemas/evidence.schema.json
+++ b/schemas/evidence.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:evidence:v1",
+  "title": "mar21 Evidence Manifest (v1)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["id", "sourceRef", "path", "contentType", "redacted"],
+    "properties": {
+      "id": { "type": "string", "minLength": 1 },
+      "sourceRef": { "type": "string", "minLength": 3 },
+      "derivedFrom": { "type": "string" },
+      "path": { "type": "string", "minLength": 3 },
+      "contentType": { "type": "string", "minLength": 3 },
+      "redacted": { "type": "boolean" },
+      "sha256": { "type": "string", "minLength": 16 },
+      "notes": { "type": "string" }
+    }
+  }
+}
+

--- a/schemas/marketing-context.schema.json
+++ b/schemas/marketing-context.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:marketing-context:v1",
+  "title": "mar21 Marketing Context (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "workspace", "company", "businessModel", "goals", "constraints"],
+  "properties": {
+    "apiVersion": { "const": "mar21/v1" },
+    "workspace": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,31}$"
+    },
+    "company": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["name", "industry", "region", "languages"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "industry": { "type": "string", "minLength": 1 },
+        "region": { "type": "string", "minLength": 1 },
+        "languages": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 2 }
+        }
+      }
+    },
+    "businessModel": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["segment", "monetization", "pricing"],
+      "properties": {
+        "segment": {
+          "type": "string",
+          "enum": ["b2b_saas", "b2c_saas", "ecommerce", "b2b_industrial", "agency", "other"]
+        },
+        "monetization": { "type": "string", "minLength": 1 },
+        "pricing": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["currency"],
+          "properties": {
+            "avgOrderValue": { "type": ["number", "null"], "minimum": 0 },
+            "avgContractValue": { "type": ["number", "null"], "minimum": 0 },
+            "currency": { "type": "string", "minLength": 3, "maxLength": 3 }
+          }
+        }
+      }
+    },
+    "goToMarket": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["stage", "channels"],
+      "properties": {
+        "stage": { "type": "string", "minLength": 1 },
+        "channels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["enabled", "primary"],
+            "properties": {
+              "enabled": { "type": "boolean" },
+              "primary": { "type": "boolean" }
+            }
+          }
+        }
+      }
+    },
+    "goals": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["primaryKpi", "secondaryKpis", "kpiTree"],
+      "properties": {
+        "primaryKpi": { "type": "string", "minLength": 1 },
+        "secondaryKpis": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "kpiTree": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "leading": { "type": "array", "items": { "type": "string" } },
+              "lagging": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        }
+      }
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["compliance", "autonomy", "budgets"],
+      "properties": {
+        "compliance": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["gdpr", "sensitiveData"],
+          "properties": {
+            "gdpr": { "type": "boolean" },
+            "sensitiveData": { "type": "boolean" }
+          }
+        },
+        "brandVoice": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "tone": { "type": "string" },
+            "doNotSay": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "autonomy": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["defaultMode", "allowlist"],
+          "properties": {
+            "defaultMode": { "enum": ["advisory", "supervised", "autonomous"] },
+            "allowlist": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": ["tool", "operation"],
+                "properties": {
+                  "tool": { "type": "string", "minLength": 1 },
+                  "operation": { "type": "string", "minLength": 1 },
+                  "maxDailyImpact": { "type": "object", "additionalProperties": true }
+                }
+              }
+            }
+          }
+        },
+        "budgets": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["monthly"],
+          "properties": {
+            "monthly": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": ["total", "breakdown"],
+              "properties": {
+                "total": { "type": "number", "minimum": 0 },
+                "breakdown": {
+                  "type": "object",
+                  "additionalProperties": { "type": "number", "minimum": 0 }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:profile:v1",
+  "title": "mar21 Autopilot Profile (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "id", "steps"],
+  "properties": {
+    "apiVersion": { "const": "mar21/profile-v1" },
+    "id": { "type": "string", "minLength": 1 },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["workflowId", "mode"],
+        "properties": {
+          "workflowId": { "type": "string", "minLength": 1 },
+          "mode": { "enum": ["advisory", "supervised", "autonomous"] },
+          "since": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+

--- a/schemas/repurpose-map.schema.json
+++ b/schemas/repurpose-map.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:repurpose-map:v1",
+  "title": "mar21 Repurpose Map (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "runId", "workspace", "maps"],
+  "properties": {
+    "apiVersion": { "const": "mar21/repurpose-map-v1" },
+    "runId": { "type": "string", "minLength": 10 },
+    "workspace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{1,31}$" },
+    "maps": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+  }
+}
+

--- a/schemas/request.schema.json
+++ b/schemas/request.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:request:v1",
+  "title": "mar21 Run Request (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "workflowId", "workspace", "mode"],
+  "properties": {
+    "apiVersion": { "const": "mar21/request-v1" },
+    "workflowId": { "type": "string", "minLength": 1 },
+    "workspace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{1,31}$" },
+    "mode": { "enum": ["advisory", "supervised", "autonomous"] },
+    "since": { "type": "string", "pattern": "^P" },
+    "params": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "research": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "questions": { "type": "array", "items": { "type": "string" } },
+            "competitorUrls": { "type": "array", "items": { "type": "string" } },
+            "sources": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "drive": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "fileIds": { "type": "array", "items": { "type": "string" } },
+                    "folderIds": { "type": "array", "items": { "type": "string" } },
+                    "query": { "type": ["string", "null"] },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "maxDownloads": { "type": "number", "minimum": 0 },
+                        "maxFileSizeMB": { "type": "number", "minimum": 0 }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:run:v1",
+  "title": "mar21 Run Metadata (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "runId", "workspace", "workflowId", "mode", "startedAt"],
+  "properties": {
+    "apiVersion": { "const": "mar21/run-v1" },
+    "runId": { "type": "string", "minLength": 10 },
+    "workspace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{1,31}$" },
+    "workflowId": { "type": "string", "minLength": 1 },
+    "mode": { "enum": ["advisory", "supervised", "autonomous"] },
+    "since": { "type": "string" },
+    "startedAt": { "type": "string", "format": "date-time" },
+    "finishedAt": { "type": "string", "format": "date-time" },
+    "connectorsUsed": { "type": "array", "items": { "type": "string" } },
+    "writesAttempted": { "type": "boolean" }
+  }
+}
+

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:skill:v1",
+  "title": "mar21 Skill Manifest (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "id", "domain", "description", "inputs", "outputs", "usesConnectors", "risk", "artifacts", "idempotency"],
+  "properties": {
+    "apiVersion": { "const": "mar21/skill-v1" },
+    "id": { "type": "string", "minLength": 3 },
+    "domain": { "type": "string", "minLength": 2 },
+    "description": { "type": "string", "minLength": 1 },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["schema"],
+      "properties": {
+        "schema": { "type": "object" }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["schema"],
+      "properties": {
+        "schema": { "type": "object" }
+      }
+    },
+    "usesConnectors": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "risk": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["level", "writes"],
+      "properties": {
+        "level": { "enum": ["none", "low", "medium", "high"] },
+        "writes": { "type": "boolean" }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["produces"],
+      "properties": {
+        "produces": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        }
+      }
+    },
+    "idempotency": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["strategy"],
+      "properties": {
+        "strategy": { "enum": ["pure", "snapshot_based", "tool_write"] }
+      }
+    }
+  }
+}
+

--- a/schemas/todos.schema.json
+++ b/schemas/todos.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:mar21:schema:todos:v1",
+  "title": "mar21 Todos (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["apiVersion", "workspace", "tasks"],
+  "properties": {
+    "apiVersion": { "const": "mar21/todos-v1" },
+    "workspace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{1,31}$" },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["taskId", "title", "status", "owner", "priority", "createdAt", "createdBy"],
+        "properties": {
+          "taskId": { "type": "string", "pattern": "^T-[0-9]{8}-[0-9]{3}(-[0-9]{6}-[a-z0-9]{4})?$" },
+          "title": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "status": { "enum": ["open", "in_progress", "blocked", "done", "canceled"] },
+          "owner": { "type": "string", "minLength": 1 },
+          "dueDate": { "type": "string", "format": "date" },
+          "priority": { "enum": ["p0", "p1", "p2", "p3"] },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" },
+          "createdBy": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["runId", "opId"],
+            "properties": {
+              "runId": { "type": "string", "minLength": 10 },
+              "opId": { "type": "string", "minLength": 1 }
+            }
+          },
+          "evidenceRef": { "type": "array", "items": { "type": "string" } },
+          "outcome": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Closes #1.\n\n- Imports manifesto/spec docs, schemas, and examples into the GitHub repo.\n- Removes local-path references.\n- Adds a repo-appropriate .gitignore.