### PR TITLE
v0.1: CLI schema validation (examples)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,10 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "commander": "^13.1.0"
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "commander": "^13.1.0",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { Command } from "commander";
+import process from "node:process";
+import { validateExamples } from "./validate.js";
 
 const program = new Command();
 
@@ -21,8 +23,9 @@ program
   .command("validate")
   .description("Validate artifacts against schemas (v0.1: stub)")
   .option("--examples", "Validate examples/", false)
-  .action(() => {
-    console.log("mar21 validate: not implemented yet (see docs/SCHEMAS.md).");
+  .action((opts: { examples?: boolean }) => {
+    if (opts.examples) process.exit(validateExamples());
+    console.log("Nothing to validate. Use --examples for now.");
   });
 
 program

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -1,0 +1,126 @@
+import Ajv2020Import from "ajv/dist/2020.js";
+import addFormatsImport from "ajv-formats";
+import type { ErrorObject } from "ajv";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import YAML from "yaml";
+
+type ValidateResult = { ok: true } | { ok: false; errors: string[] };
+
+type Ajv2020Class = typeof import("ajv/dist/2020.js").default;
+type Ajv2020Instance = InstanceType<Ajv2020Class>;
+
+const Ajv2020 = Ajv2020Import as unknown as Ajv2020Class;
+const addFormats = ((addFormatsImport as unknown as { default?: unknown }).default ??
+  addFormatsImport) as unknown as (ajv: Ajv2020Instance) => void;
+
+function repoRootFromCliDir(cliDir: string): string {
+  return path.resolve(cliDir, "../../..");
+}
+
+function loadJsonFile(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+function loadYamlFile(filePath: string): unknown {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  return YAML.parse(raw);
+}
+
+function buildAjv(schemaDir: string): Ajv2020Instance {
+  const ajv = new Ajv2020({
+    allErrors: true,
+    strict: false
+  });
+  addFormats(ajv);
+
+  for (const entry of fs.readdirSync(schemaDir)) {
+    if (!entry.endsWith(".json")) continue;
+    const schemaPath = path.join(schemaDir, entry);
+    const schema = loadJsonFile(schemaPath) as any;
+    ajv.addSchema(schema);
+  }
+
+  return ajv;
+}
+
+function schemaForExampleFilename(filename: string): string | null {
+  const map: Record<string, string> = {
+    "marketing-context.yaml": "urn:mar21:schema:marketing-context:v1",
+    "request.yaml": "urn:mar21:schema:request:v1",
+    "changeset.yaml": "urn:mar21:schema:changeset:v1",
+    "run.json": "urn:mar21:schema:run:v1",
+    "skill.yaml": "urn:mar21:schema:skill:v1",
+    "profile.yaml": "urn:mar21:schema:profile:v1",
+    "connector.yaml": "urn:mar21:schema:connector:v1",
+    "evidence.json": "urn:mar21:schema:evidence:v1",
+    "todos.yaml": "urn:mar21:schema:todos:v1",
+    "creative-brief.yaml": "urn:mar21:schema:creative-brief:v1",
+    "asset-manifest.yaml": "urn:mar21:schema:asset-manifest:v1",
+    "distribution-plan.yaml": "urn:mar21:schema:distribution-plan:v1",
+    "repurpose-map.yaml": "urn:mar21:schema:repurpose-map:v1"
+  };
+  return map[filename] ?? null;
+}
+
+function validateOne(ajv: Ajv2020Instance, schemaId: string, filePath: string): ValidateResult {
+  const validate = ajv.getSchema(schemaId);
+  if (!validate) {
+    return { ok: false, errors: [`schema not found: ${schemaId}`] };
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+  let instance: unknown;
+  if (ext === ".json") instance = loadJsonFile(filePath);
+  else instance = loadYamlFile(filePath);
+
+  const ok = validate(instance);
+  if (ok) return { ok: true };
+
+  const errors =
+    validate.errors?.map((e: ErrorObject) => `${e.instancePath || "/"} ${e.message ?? "invalid"}`) ??
+    ["invalid"];
+  return { ok: false, errors };
+}
+
+export function validateExamples(): number {
+  const cliDir = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = repoRootFromCliDir(cliDir);
+  const schemaDir = path.join(repoRoot, "schemas");
+  const examplesDir = path.join(repoRoot, "examples");
+
+  if (!fs.existsSync(schemaDir)) {
+    console.error(`schemas/ not found at: ${schemaDir}`);
+    return 11;
+  }
+  if (!fs.existsSync(examplesDir)) {
+    console.error(`examples/ not found at: ${examplesDir}`);
+    return 11;
+  }
+
+  const ajv = buildAjv(schemaDir);
+
+  let failures = 0;
+  for (const entry of fs.readdirSync(examplesDir)) {
+    const schemaId = schemaForExampleFilename(entry);
+    if (!schemaId) continue;
+
+    const filePath = path.join(examplesDir, entry);
+    const res = validateOne(ajv, schemaId, filePath);
+    if (res.ok) continue;
+
+    failures += 1;
+    console.error(`✗ ${path.relative(process.cwd(), filePath)}`);
+    for (const err of res.errors) console.error(`  - ${err}`);
+  }
+
+  if (failures === 0) {
+    console.log("✓ examples/ validate against schemas/");
+    return 0;
+  }
+
+  console.error(`\n${failures} file(s) failed validation.`);
+  return 11;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,18 @@ importers:
 
   packages/cli:
     dependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.18.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.18.0)
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      yaml:
+        specifier: ^2.7.0
+        version: 2.8.2
     devDependencies:
       '@types/node':
         specifier: ^22.13.10
@@ -194,6 +203,17 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
@@ -203,6 +223,12 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -210,6 +236,13 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -226,6 +259,11 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
 snapshots:
 
@@ -311,6 +349,17 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   commander@13.1.0: {}
 
   esbuild@0.27.3:
@@ -342,12 +391,20 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
   fsevents@2.3.3:
     optional: true
 
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  json-schema-traverse@1.0.0: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -361,3 +418,5 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  yaml@2.8.2: {}


### PR DESCRIPTION
Closes #4.

## What
- Adds `mar21 validate --examples` to validate `examples/*` against JSON Schemas in `schemas/`.
- Uses Ajv (draft 2020-12) + `yaml` parsing for `.yaml` example files.

## How
- Loads all schemas from `schemas/` (by `$id`), then validates known example filenames against their schema ids.
- Exits with code `0` on success, `11` on any validation failure.

## Test
- `pnpm -C packages/cli build`
- `node packages/cli/dist/index.js validate --examples`
