### PR TITLE
v0.1: run engine (plan) + workspace init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dist/
 **/runs/
 **/cache/
 
+# Local workspaces (user data)
+workspaces/*
+!workspaces/README.md
+
 # OS / editor
 .DS_Store
 .idea/

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,18 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import process from "node:process";
+import { initWorkspace } from "./init.js";
+import { runPlan } from "./run-engine.js";
 import { validateExamples } from "./validate.js";
+
+process.on("uncaughtException", (err) => {
+  const exitCode = (err as Error & { exitCode?: number }).exitCode;
+  if (exitCode) {
+    console.error((err as Error).message);
+    process.exit(exitCode);
+  }
+  throw err;
+});
 
 const program = new Command();
 
@@ -12,11 +23,12 @@ program
 
 program
   .command("init")
-  .description("Initialize a workspace skeleton (v0.1: stub)")
+  .description("Initialize a workspace skeleton (v0.1)")
   .option("--workspace <id>", "Workspace id")
   .option("--force", "Overwrite if exists", false)
-  .action(() => {
-    console.log("mar21 init: not implemented yet (see docs/SPECS.md).");
+  .action((opts: { workspace?: string; force?: boolean }) => {
+    const res = initWorkspace({ workspace: opts.workspace, force: opts.force });
+    console.log(`✓ workspace initialized: ${res.workspace} (${res.root})`);
   });
 
 program
@@ -30,11 +42,44 @@ program
 
 program
   .command("plan")
-  .description("Run a workflow in planning mode (v0.1: stub)")
+  .description("Run a workflow in planning mode (v0.1: artifacts-only)")
   .argument("<workflowId>", "Workflow id")
-  .action((workflowId: string) => {
-    console.log(`mar21 plan ${workflowId}: not implemented yet (see docs/WORKFLOWS.md).`);
-  });
+  .requiredOption("--workspace <id>", "Workspace id")
+  .option("--mode <mode>", "advisory|supervised|autonomous")
+  .option("--since <duration>", "ISO 8601 duration, e.g. P7D or P28D")
+  .option("--dry-run", "Never apply writes (still produces ChangeSet)", false)
+  .option("--json", "Print machine-readable run summary", false)
+  .action(
+    (
+      workflowId: string,
+      opts: {
+        workspace: string;
+        mode?: string;
+        since?: string;
+        dryRun?: boolean;
+        json?: boolean;
+      }
+    ) => {
+    const mode =
+      opts.mode === "advisory" || opts.mode === "supervised" || opts.mode === "autonomous"
+        ? opts.mode
+        : undefined;
+    const summary = runPlan(workflowId, {
+      workspace: opts.workspace,
+      mode,
+      since: opts.since,
+      dryRun: Boolean(opts.dryRun),
+      json: Boolean(opts.json)
+    });
+
+    if (opts.json) {
+      process.stdout.write(`${JSON.stringify(summary)}\n`);
+      return;
+    }
+    console.log(`✓ run created: ${summary.runId}`);
+    console.log(`  - ${summary.paths.runDir}`);
+    }
+  );
 
 program
   .command("apply")

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import YAML from "yaml";
+import { ensureDir } from "./workspace.js";
+
+export type InitOptions = {
+  workspace?: string;
+  force?: boolean;
+};
+
+function repoRootFromCwd(): string {
+  return process.cwd();
+}
+
+function validateWorkspaceId(id: string): boolean {
+  return /^[a-z0-9][a-z0-9-]{1,31}$/.test(id);
+}
+
+export function initWorkspace(opts: InitOptions): { workspace: string; root: string } {
+  const workspaceId = opts.workspace?.trim();
+  if (!workspaceId) {
+    const err = new Error("missing --workspace");
+    (err as Error & { exitCode?: number }).exitCode = 2;
+    throw err;
+  }
+  if (!validateWorkspaceId(workspaceId)) {
+    const err = new Error(
+      `invalid workspace id: ${workspaceId} (expected /^[a-z0-9][a-z0-9-]{1,31}$/)`
+    );
+    (err as Error & { exitCode?: number }).exitCode = 10;
+    throw err;
+  }
+
+  const repoRoot = repoRootFromCwd();
+  const wsRoot = path.join(repoRoot, "workspaces", workspaceId);
+
+  if (fs.existsSync(wsRoot)) {
+    if (!opts.force) {
+      const err = new Error(`workspace already exists: ${wsRoot} (use --force to overwrite)`);
+      (err as Error & { exitCode?: number }).exitCode = 10;
+      throw err;
+    }
+  }
+
+  ensureDir(path.join(wsRoot, "secrets"));
+  ensureDir(path.join(wsRoot, "_cfg"));
+  ensureDir(path.join(wsRoot, "profiles"));
+  ensureDir(path.join(wsRoot, "memory"));
+  ensureDir(path.join(wsRoot, "cache", "snapshots"));
+  ensureDir(path.join(wsRoot, "runs"));
+
+  const contextPath = path.join(wsRoot, "marketing-context.yaml");
+  if (!fs.existsSync(contextPath) || opts.force) {
+    fs.writeFileSync(
+      contextPath,
+      YAML.stringify({
+        apiVersion: "mar21/v1",
+        workspace: workspaceId,
+        company: {
+          name: "Your Company",
+          industry: "B2B SaaS",
+          region: "EU",
+          languages: ["en", "de"]
+        },
+        businessModel: {
+          segment: "b2b_saas",
+          monetization: "subscription",
+          pricing: { avgOrderValue: null, avgContractValue: 1200, currency: "EUR" }
+        },
+        goToMarket: {
+          stage: "validation",
+          channels: {
+            seo: { enabled: true, primary: true },
+            paid_social: { enabled: true, primary: false },
+            lifecycle_email: { enabled: true, primary: false }
+          }
+        },
+        goals: {
+          primaryKpi: "pipeline",
+          secondaryKpis: ["traffic", "leads"],
+          kpiTree: {
+            pipeline: { leading: ["mqls", "sqls"], lagging: ["closed_won"] }
+          }
+        },
+        constraints: {
+          compliance: { gdpr: true, sensitiveData: false },
+          brandVoice: { tone: "professional", doNotSay: ["guaranteed", "best in class"] },
+          autonomy: { defaultMode: "supervised", allowlist: [] },
+          budgets: { monthly: { total: 0, breakdown: {} } }
+        }
+      })
+    );
+  }
+
+  const todosPath = path.join(wsRoot, "todos.yaml");
+  if (!fs.existsSync(todosPath) || opts.force) {
+    fs.writeFileSync(
+      todosPath,
+      YAML.stringify({ apiVersion: "mar21/todos-v1", workspace: workspaceId, tasks: [] })
+    );
+  }
+
+  const secretsEnvPath = path.join(wsRoot, "secrets", ".env");
+  if (!fs.existsSync(secretsEnvPath)) {
+    fs.writeFileSync(
+      secretsEnvPath,
+      `# mar21 workspace secrets (never commit)\n# Example:\n# GSC_CLIENT_ID=\n# GSC_CLIENT_SECRET=\n`,
+      "utf-8"
+    );
+  }
+
+  for (const name of ["learnings.yaml", "winners.yaml", "losers.yaml", "exclusions.yaml"] as const) {
+    const p = path.join(wsRoot, "memory", name);
+    if (!fs.existsSync(p) || opts.force) fs.writeFileSync(p, "# mar21 memory (v1)\n", "utf-8");
+  }
+
+  return { workspace: workspaceId, root: path.relative(repoRoot, wsRoot) };
+}
+

--- a/packages/cli/src/run-engine.ts
+++ b/packages/cli/src/run-engine.ts
@@ -1,0 +1,214 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import YAML from "yaml";
+import {
+  defaultModeFromContext,
+  ensureDir,
+  Mode,
+  readYamlFile,
+  resolveWorkspaceId,
+  slugifyWorkflowId,
+  utcTimestampForRunId,
+  workspaceRoot
+} from "./workspace.js";
+
+export type RunSummary = {
+  runId: string;
+  workspace: string;
+  workflowId: string;
+  mode: Mode;
+  paths: { runDir: string; changeset: string };
+};
+
+export type PlanCommandOptions = {
+  workspace?: string;
+  mode?: Mode;
+  since?: string;
+  dryRun?: boolean;
+  json?: boolean;
+};
+
+function repoRootFromCwd(): string {
+  return process.cwd();
+}
+
+function pickRunId(runsDir: string, baseRunId: string): string {
+  const candidate = (n?: number) => (n ? `${baseRunId}_${n}` : baseRunId);
+  if (!fs.existsSync(path.join(runsDir, candidate()))) return candidate();
+
+  for (let n = 2; n < 10_000; n += 1) {
+    const c = candidate(n);
+    if (!fs.existsSync(path.join(runsDir, c))) return c;
+  }
+  throw new Error(`could not allocate runId after many collisions: ${baseRunId}`);
+}
+
+function writeJson(filePath: string, data: unknown): void {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+}
+
+function writeText(filePath: string, data: string): void {
+  fs.writeFileSync(filePath, data.endsWith("\n") ? data : `${data}\n`, "utf-8");
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function planTemplate(workflowId: string): string {
+  return `# Plan — ${workflowId}
+
+## Goal
+- (Single sentence) What outcome do we want?
+
+## KPI Tree
+- Primary KPI:
+- Leading indicators:
+- Lagging indicators:
+
+## Hypotheses (ranked)
+1) …
+2) …
+3) …
+
+## Tasks (owners, ETA, measurement)
+- [ ] Task — owner — ETA — measurement
+
+## Assumptions & open questions
+- Assumption:
+- Open question:
+
+## Guardrails (what we won’t do)
+- …
+`;
+}
+
+function reportTemplate(workflowId: string): string {
+  return `# Report — ${workflowId}
+
+## What changed (deltas + evidence refs)
+- …
+
+## Why (most likely causes)
+- …
+
+## What we did / will do (linked to ChangeSet ops)
+- …
+
+## Risks & unknowns
+- …
+
+## Next checkpoint
+- …
+`;
+}
+
+function logsLine(event: Record<string, unknown>): string {
+  return `${JSON.stringify({ ts: nowIso(), level: "info", ...event })}\n`;
+}
+
+export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSummary {
+  const repoRoot = repoRootFromCwd();
+  const workspaceId = resolveWorkspaceId(opts.workspace);
+  if (!workspaceId) {
+    const err = new Error("missing --workspace (or MAR21_WORKSPACE)");
+    (err as Error & { exitCode?: number }).exitCode = 2;
+    throw err;
+  }
+
+  const wsRoot = workspaceRoot(repoRoot, workspaceId);
+  if (!fs.existsSync(wsRoot) || !fs.statSync(wsRoot).isDirectory()) {
+    const err = new Error(`workspace not found: ${workspaceId} (${wsRoot})`);
+    (err as Error & { exitCode?: number }).exitCode = 10;
+    throw err;
+  }
+
+  const contextPath = path.join(wsRoot, "marketing-context.yaml");
+  if (!fs.existsSync(contextPath)) {
+    const err = new Error(`missing marketing context: ${contextPath}`);
+    (err as Error & { exitCode?: number }).exitCode = 10;
+    throw err;
+  }
+
+  const workflowId = workflowIdRaw.trim();
+  const slug = slugifyWorkflowId(workflowId);
+  const startedAt = nowIso();
+
+  const runsDir = path.join(wsRoot, "runs");
+  ensureDir(runsDir);
+  const baseRunId = `${utcTimestampForRunId(new Date())}_${slug}`;
+  const runId = pickRunId(runsDir, baseRunId);
+  const runDir = path.join(runsDir, runId);
+
+  const inputsDir = path.join(runDir, "inputs");
+  const outputsDir = path.join(runDir, "outputs");
+  const evidenceDir = path.join(outputsDir, "evidence");
+  ensureDir(inputsDir);
+  ensureDir(evidenceDir);
+
+  const context = readYamlFile(contextPath);
+  const mode: Mode = opts.mode ?? defaultModeFromContext(context);
+  const since = opts.since ?? "P28D";
+
+  fs.copyFileSync(contextPath, path.join(inputsDir, "context.snapshot.yaml"));
+  writeText(
+    path.join(inputsDir, "request.yaml"),
+    YAML.stringify({
+      apiVersion: "mar21/request-v1",
+      workflowId,
+      workspace: workspaceId,
+      mode,
+      since,
+      params: {}
+    })
+  );
+
+  writeText(path.join(outputsDir, "plan.md"), planTemplate(workflowId));
+  writeText(path.join(outputsDir, "report.md"), reportTemplate(workflowId));
+
+  writeText(
+    path.join(runDir, "changeset.yaml"),
+    YAML.stringify({
+      apiVersion: "mar21/changeset-v1",
+      runId,
+      workspace: workspaceId,
+      mode,
+      ops: []
+    })
+  );
+
+  const logsPath = path.join(runDir, "logs.jsonl");
+  writeText(logsPath, logsLine({ event: "run.started", runId, workflowId, workspace: workspaceId }));
+  fs.appendFileSync(logsPath, logsLine({ event: "run.outputs", outputsDir: "outputs/" }), "utf-8");
+
+  writeJson(path.join(runDir, "approvals.json"), []);
+
+  const finishedAt = nowIso();
+  writeJson(path.join(runDir, "run.json"), {
+    apiVersion: "mar21/run-v1",
+    runId,
+    workspace: workspaceId,
+    workflowId,
+    mode,
+    since,
+    startedAt,
+    finishedAt,
+    connectorsUsed: [],
+    writesAttempted: false
+  });
+
+  fs.appendFileSync(logsPath, logsLine({ event: "run.finished", runId, finishedAt }), "utf-8");
+
+  return {
+    runId,
+    workspace: workspaceId,
+    workflowId,
+    mode,
+    paths: {
+      runDir: path.relative(repoRoot, runDir),
+      changeset: path.relative(repoRoot, path.join(runDir, "changeset.yaml"))
+    }
+  };
+}
+

--- a/packages/cli/src/workspace.ts
+++ b/packages/cli/src/workspace.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+
+export type Mode = "advisory" | "supervised" | "autonomous";
+
+export function slugifyWorkflowId(input: string): string {
+  const slug = input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_");
+  return slug.length > 0 ? slug : "workflow";
+}
+
+export function utcTimestampForRunId(date: Date): string {
+  const iso = date.toISOString(); // 2026-03-12T12:34:56.789Z
+  const noMs = iso.slice(0, 19); // 2026-03-12T12:34:56
+  return `${noMs.replace(/:/g, "")}Z`; // 2026-03-12T123456Z
+}
+
+export function resolveWorkspaceId(workspaceFlag?: string): string | null {
+  if (workspaceFlag && workspaceFlag.trim().length > 0) return workspaceFlag.trim();
+  const fromEnv = process.env.MAR21_WORKSPACE;
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv.trim();
+  return null;
+}
+
+export function workspaceRoot(repoRoot: string, workspaceId: string): string {
+  return path.join(repoRoot, "workspaces", workspaceId);
+}
+
+export function requireWorkspaceRoot(repoRoot: string, workspaceId: string): string {
+  const wsRoot = workspaceRoot(repoRoot, workspaceId);
+  if (!fs.existsSync(wsRoot) || !fs.statSync(wsRoot).isDirectory()) {
+    const err = new Error(`workspace not found: ${workspaceId} (${wsRoot})`) as Error & {
+      code?: string;
+    };
+    err.code = "MAR21_WORKSPACE_NOT_FOUND";
+    throw err;
+  }
+  return wsRoot;
+}
+
+export function readYamlFile(filePath: string): unknown {
+  return YAML.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+export function writeYamlFile(filePath: string, data: unknown): void {
+  const raw = YAML.stringify(data, { indent: 2 });
+  fs.writeFileSync(filePath, raw, "utf-8");
+}
+
+export function defaultModeFromContext(context: unknown): Mode {
+  if (!context || typeof context !== "object") return "supervised";
+
+  const autonomy = (context as { constraints?: { autonomy?: { defaultMode?: unknown } } })?.constraints
+    ?.autonomy;
+  const mode = autonomy?.defaultMode;
+  if (mode === "advisory" || mode === "supervised" || mode === "autonomous") return mode;
+  return "supervised";
+}
+
+export function ensureDir(dirPath: string): void {
+  fs.mkdirSync(dirPath, { recursive: true });
+}

--- a/workspaces/README.md
+++ b/workspaces/README.md
@@ -1,0 +1,11 @@
+# Workspaces (local)
+
+`mar21` workspaces live under `workspaces/<workspaceId>/` and contain local context, runs, cache snapshots, and secrets.
+
+By default, `workspaces/*` is ignored by git to prevent accidental commits of private data.
+
+Create one:
+```bash
+mar21 init --workspace acme
+```
+


### PR DESCRIPTION
Closes #5.

## What
- Implements a minimal v0.1 run engine for `mar21 plan` that creates the canonical run folder and required artifacts.
- Implements `mar21 init` to create a local workspace skeleton under `workspaces/<id>/`.
- Ignores `workspaces/*` by default to avoid committing private workspace data.

## Artifacts written per run
- `inputs/context.snapshot.yaml`
- `inputs/request.yaml`
- `outputs/plan.md`
- `outputs/report.md`
- `changeset.yaml`
- `logs.jsonl`
- `run.json`
- `approvals.json`

## Test
- `pnpm -C packages/cli build`
- `node packages/cli/dist/index.js init --workspace demo --force`
- `node packages/cli/dist/index.js plan weekly_review --workspace demo --json`
