### PR TITLE
v0.1: deep_research_sparring workflow stub

### DIFF
--- a/packages/cli/src/run-engine.ts
+++ b/packages/cli/src/run-engine.ts
@@ -104,6 +104,121 @@ function reportTemplate(workflowId: string): string {
 `;
 }
 
+function deepResearchPackTemplate(args: {
+  workspaceId: string;
+  runId: string;
+  accessedDate: string;
+}): string {
+  const accessed = args.accessedDate.slice(0, 10);
+  return `# Research Pack — deep_research_sparring
+
+This is a **stub research pack** (v0.1) intended to prove the artifact contract:
+- claims are tied to sources via \`[S#]\`
+- sources can be **public** and **private** (e.g. Drive refs)
+
+## Research questions
+- What is the highest-leverage positioning wedge for the next 30 days?
+- Which channels are most likely to drive the primary KPI with lowest execution risk?
+- What creative system (brief → variants → distribution) should we stand up first?
+
+## Findings
+- “Evidence-based loops” beat ad-hoc tactics: every recommendation must map to a KPI node and a measurable next action. [S1]
+- For this workspace, “auditability / control” is a plausible differentiation angle worth testing in messaging and creative. [S2]
+- Autonomy defaults to supervised; we should express execution as tasks + drafts until measurement is stable. [S3]
+
+## Implications for strategy
+- Positioning: test an “auditability/control” narrative in 2–3 variants (short, medium, proof-led).
+- Channel mix: start with one capture channel + one nurture channel; keep everything traceable via UTMs.
+- Creative system: produce a reusable brief + asset naming rules so learnings compound.
+
+## Gaps / unknowns
+- We have no real category/competitor scrape in v0.1; add public sources and competitor URLs in a later iteration.
+- Private-doc ingestion is represented as evidence stubs only; real Drive pulls come later.
+
+## Sources
+- [S1] (public_url) mar21 Best Practices — mar21 repo — https://github.com/SebastianKater-Wegscheider/mar21/blob/main/docs/BEST_PRACTICES.md — accessed ${accessed}
+- [S2] (private_doc) ICP interviews memo (fixture) — Internal — drive:fileId:pdf987 — accessed ${accessed}
+- [S3] (internal_snapshot) Context snapshot — ${args.workspaceId} — inputs/context.snapshot.yaml — accessed ${accessed}
+`;
+}
+
+function deepDecisionLogTemplate(accessedDate: string): string {
+  const accessed = accessedDate.slice(0, 10);
+  return `# Decision Log — deep_research_sparring
+
+## Date
+- ${accessed}
+
+## Decisions
+- Keep default mode \`supervised\` until KPI definitions + tracking are stable.
+- Express execution as \`mar21.todo.*\` tasks and drafts first; only then allow tool writes.
+
+## Assumptions
+- The workspace’s primary KPI is correctly defined in \`marketing-context.yaml\`.
+- A “control/auditability” angle resonates with the target segment (to be validated).
+
+## Tradeoffs
+- We prefer auditability and repeatability over speed of fully-automated changes.
+`;
+}
+
+function deepResearchSparringOps(): Array<Record<string, unknown>> {
+  return [
+    {
+      id: "todo_define_message_variants",
+      tool: "mar21",
+      operation: "mar21.todo.create",
+      risk: "low",
+      requiresApproval: true,
+      params: {
+        task: {
+          title: "Draft 3 messaging variants (auditability/control angle)",
+          description:
+            "Create short/medium/proof-led versions. Use Research Pack findings and ensure claims are supportable.",
+          owner: "operator",
+          priority: "p1",
+          tags: ["copy", "positioning"],
+          evidenceRef: ["outputs/research_pack.md"]
+        }
+      }
+    },
+    {
+      id: "todo_create_creative_brief_v1",
+      tool: "mar21",
+      operation: "mar21.todo.create",
+      risk: "low",
+      requiresApproval: true,
+      params: {
+        task: {
+          title: "Create Creative Brief v1 + variation system",
+          description: "One brief that can feed ads + landing page + lifecycle email. Define naming/versioning.",
+          owner: "operator",
+          priority: "p1",
+          tags: ["creative", "system"],
+          evidenceRef: ["outputs/research_pack.md"]
+        }
+      }
+    },
+    {
+      id: "todo_distribution_plan_v1",
+      tool: "mar21",
+      operation: "mar21.todo.create",
+      risk: "low",
+      requiresApproval: true,
+      params: {
+        task: {
+          title: "Create Distribution Plan v1 (repurpose + syndicate)",
+          description: "Define the first repurpose map and where each asset gets distributed.",
+          owner: "operator",
+          priority: "p2",
+          tags: ["distribution"],
+          evidenceRef: ["outputs/research_pack.md"]
+        }
+      }
+    }
+  ];
+}
+
 function logsLine(event: Record<string, unknown>): string {
   return `${JSON.stringify({ ts: nowIso(), level: "info", ...event })}\n`;
 }
@@ -167,16 +282,45 @@ export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSum
   writeText(path.join(outputsDir, "plan.md"), planTemplate(workflowId));
   writeText(path.join(outputsDir, "report.md"), reportTemplate(workflowId));
 
-  writeText(
-    path.join(runDir, "changeset.yaml"),
-    YAML.stringify({
-      apiVersion: "mar21/changeset-v1",
-      runId,
-      workspace: workspaceId,
-      mode,
-      ops: []
-    })
-  );
+  const changeset: Record<string, unknown> = {
+    apiVersion: "mar21/changeset-v1",
+    runId,
+    workspace: workspaceId,
+    mode,
+    ops: []
+  };
+
+  if (slug === "deep_research_sparring") {
+    const accessedAt = nowIso();
+
+    writeText(path.join(outputsDir, "research_pack.md"), deepResearchPackTemplate({ workspaceId, runId, accessedDate: accessedAt }));
+    writeText(path.join(outputsDir, "decision_log.md"), deepDecisionLogTemplate(accessedAt));
+
+    // Optional fixture evidence (no real APIs yet): emulate a redacted Drive extract.
+    writeText(
+      path.join(evidenceDir, "gdrive_pdf987.md"),
+      `# Redacted extract (fixture)\n\n- Objection: “We need control / audit trails.”\n- Implication: messaging + proof should address auditability.\n`
+    );
+    writeJson(
+      path.join(evidenceDir, "evidence.json"),
+      [
+        {
+          id: "E1",
+          sourceRef: "drive:fileId:pdf987",
+          derivedFrom: "private_doc",
+          path: "outputs/evidence/gdrive_pdf987.md",
+          contentType: "text/markdown",
+          redacted: true,
+          sha256: "00000000000000000000000000000000",
+          notes: "Fixture evidence for v0.1; redacted."
+        }
+      ]
+    );
+
+    changeset.ops = deepResearchSparringOps();
+  }
+
+  writeText(path.join(runDir, "changeset.yaml"), YAML.stringify(changeset));
 
   const logsPath = path.join(runDir, "logs.jsonl");
   writeText(logsPath, logsLine({ event: "run.started", runId, workflowId, workspace: workspaceId }));
@@ -211,4 +355,3 @@ export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSum
     }
   };
 }
-


### PR DESCRIPTION
Closes #7.

## What
- Implements `mar21 plan deep_research_sparring` as an **artifact-complete v0.1 stub** (no real APIs yet).

## Outputs (in the run folder)
- `outputs/research_pack.md` with `[S#]` citations + Sources section
- `outputs/decision_log.md`
- `outputs/plan.md`, `outputs/report.md`
- `changeset.yaml` with `mar21.todo.create` suggestions
- Fixture evidence under `outputs/evidence/` to demonstrate private-doc refs (Drive)

## Test
- `pnpm -C packages/cli build`
- `mar21 init --workspace demo --force`
- `mar21 plan deep_research_sparring --workspace demo`
