### PR TITLE
v0.1: mar21 run (profiles) + workspace env fallback

### DIFF
--- a/packages/cli/src/apply-engine.ts
+++ b/packages/cli/src/apply-engine.ts
@@ -3,8 +3,7 @@ import path from "node:path";
 import process from "node:process";
 import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
-import YAML from "yaml";
-import { ensureDir, readYamlFile, writeYamlFile } from "./workspace.js";
+import { ensureDir, readYamlFile, resolveWorkspaceId, writeYamlFile } from "./workspace.js";
 
 type ChangeSetOp = {
   id: string;
@@ -41,7 +40,7 @@ type ApplyResult = {
 };
 
 export type ApplyOptions = {
-  workspace: string;
+  workspace?: string;
   runId: string;
   yes?: boolean;
   json?: boolean;
@@ -296,9 +295,16 @@ function readChangeSet(runDir: string): ChangeSet {
 
 export async function applyRunChangeset(opts: ApplyOptions): Promise<{ summary: ApplySummary; exitCode: number }> {
   const repoRoot = repoRootFromCwd();
-  const wsRoot = path.join(repoRoot, "workspaces", opts.workspace);
+  const workspaceId = resolveWorkspaceId(opts.workspace);
+  if (!workspaceId) {
+    const err = new Error("missing --workspace (or MAR21_WORKSPACE)");
+    (err as Error & { exitCode?: number }).exitCode = 2;
+    throw err;
+  }
+
+  const wsRoot = path.join(repoRoot, "workspaces", workspaceId);
   if (!fs.existsSync(wsRoot)) {
-    const err = new Error(`workspace not found: ${opts.workspace}`);
+    const err = new Error(`workspace not found: ${workspaceId}`);
     (err as Error & { exitCode?: number }).exitCode = 10;
     throw err;
   }
@@ -358,7 +364,6 @@ export async function applyRunChangeset(opts: ApplyOptions): Promise<{ summary: 
   appendLogLine(runDir, { event: "apply.finished", runId: opts.runId });
 
   const hadFailures = results.some((r) => r.status === "failed");
-  const summary: ApplySummary = { runId: opts.runId, workspace: opts.workspace, results };
+  const summary: ApplySummary = { runId: opts.runId, workspace: workspaceId, results };
   return { summary, exitCode: hadFailures ? 30 : 0 };
 }
-

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import process from "node:process";
 import { applyRunChangeset } from "./apply-engine.js";
 import { initWorkspace } from "./init.js";
+import { runCadence } from "./run-cadence.js";
 import { runPlan } from "./run-engine.js";
 import { validateExamples } from "./validate.js";
 
@@ -45,7 +46,7 @@ program
   .command("plan")
   .description("Run a workflow in planning mode (v0.1: artifacts-only)")
   .argument("<workflowId>", "Workflow id")
-  .requiredOption("--workspace <id>", "Workspace id")
+  .option("--workspace <id>", "Workspace id")
   .option("--mode <mode>", "advisory|supervised|autonomous")
   .option("--since <duration>", "ISO 8601 duration, e.g. P7D or P28D")
   .option("--dry-run", "Never apply writes (still produces ChangeSet)", false)
@@ -54,7 +55,7 @@ program
     (
       workflowId: string,
       opts: {
-        workspace: string;
+        workspace?: string;
         mode?: string;
         since?: string;
         dryRun?: boolean;
@@ -83,17 +84,69 @@ program
   );
 
 program
+  .command("run")
+  .description("Execute a cadence profile once (v0.1: artifacts-only)")
+  .argument("<cadence>", "daily|weekly|monthly")
+  .option("--workspace <id>", "Workspace id")
+  .option("--profile <profileId>", "Profile id (default: cadence)")
+  .option("--mode <mode>", "advisory|supervised|autonomous")
+  .option("--since <duration>", "ISO 8601 duration, e.g. P7D or P28D")
+  .option("--dry-run", "Never apply writes (still produces ChangeSet)", false)
+  .option("--json", "Print machine-readable run summary", false)
+  .action(
+    (
+      cadence: string,
+      opts: {
+        workspace?: string;
+        profile?: string;
+        mode?: string;
+        since?: string;
+        dryRun?: boolean;
+        json?: boolean;
+      }
+    ) => {
+      const c = cadence.trim();
+      if (c !== "daily" && c !== "weekly" && c !== "monthly") {
+        const err = new Error(`invalid cadence: ${cadence} (expected daily|weekly|monthly)`);
+        (err as Error & { exitCode?: number }).exitCode = 2;
+        throw err;
+      }
+
+      const mode =
+        opts.mode === "advisory" || opts.mode === "supervised" || opts.mode === "autonomous"
+          ? opts.mode
+          : undefined;
+      const summary = runCadence({
+        cadence: c,
+        workspace: opts.workspace,
+        profile: opts.profile,
+        mode,
+        since: opts.since,
+        dryRun: Boolean(opts.dryRun)
+      });
+
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify(summary)}\n`);
+        return;
+      }
+
+      console.log(`✓ cadence run: ${summary.cadence} (${summary.profileId})`);
+      for (const r of summary.runs) console.log(`  - ${r.runId}`);
+    }
+  );
+
+program
   .command("apply")
   .description("Apply a run changeset (v0.1: internal ops only)")
   .argument("<runId>", "Run id")
-  .requiredOption("--workspace <id>", "Workspace id")
+  .option("--workspace <id>", "Workspace id")
   .option("--yes", "Auto-approve all required approvals", false)
   .option("--json", "Print machine-readable apply summary", false)
   .action(
     async (
       runId: string,
       opts: {
-        workspace: string;
+        workspace?: string;
         yes?: boolean;
         json?: boolean;
       }

--- a/packages/cli/src/profile.ts
+++ b/packages/cli/src/profile.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+import { readYamlFile } from "./workspace.js";
+
+export type ProfileStep = {
+  workflowId: string;
+  mode: "advisory" | "supervised" | "autonomous";
+  since?: string;
+};
+
+export type Profile = {
+  apiVersion: "mar21/profile-v1";
+  id: string;
+  steps: ProfileStep[];
+};
+
+export function loadProfile(profilePath: string): Profile {
+  if (!fs.existsSync(profilePath)) {
+    const err = new Error(`profile not found: ${profilePath}`);
+    (err as Error & { exitCode?: number }).exitCode = 10;
+    throw err;
+  }
+  const doc = readYamlFile(profilePath) as any;
+  if (!doc || doc.apiVersion !== "mar21/profile-v1" || !Array.isArray(doc.steps)) {
+    const err = new Error(`invalid profile file: ${profilePath}`);
+    (err as Error & { exitCode?: number }).exitCode = 11;
+    throw err;
+  }
+  const steps = (doc.steps as any[]).map((s) => ({
+    workflowId: String(s.workflowId ?? "").trim(),
+    mode: s.mode as ProfileStep["mode"],
+    since: s.since ? String(s.since) : undefined
+  }));
+  if (!steps.length || steps.some((s) => !s.workflowId)) {
+    const err = new Error(`profile has no valid steps: ${profilePath}`);
+    (err as Error & { exitCode?: number }).exitCode = 11;
+    throw err;
+  }
+  return { apiVersion: "mar21/profile-v1", id: String(doc.id ?? ""), steps };
+}
+
+export function profilePathFor(wsRoot: string, profileId: string): string {
+  return path.join(wsRoot, "profiles", `${profileId}.yaml`);
+}
+

--- a/packages/cli/src/run-cadence.ts
+++ b/packages/cli/src/run-cadence.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { loadProfile, profilePathFor } from "./profile.js";
+import { runPlan, RunSummary } from "./run-engine.js";
+import { Mode, resolveWorkspaceId, workspaceRoot } from "./workspace.js";
+
+export type RunCadenceOptions = {
+  cadence: "daily" | "weekly" | "monthly";
+  workspace?: string;
+  profile?: string;
+  mode?: Mode;
+  since?: string;
+  dryRun?: boolean;
+};
+
+export type RunCadenceSummary = {
+  cadence: "daily" | "weekly" | "monthly";
+  workspace: string;
+  profileId: string;
+  runs: RunSummary[];
+};
+
+function repoRootFromCwd(): string {
+  return process.cwd();
+}
+
+export function runCadence(opts: RunCadenceOptions): RunCadenceSummary {
+  const repoRoot = repoRootFromCwd();
+  const workspaceId = resolveWorkspaceId(opts.workspace);
+  if (!workspaceId) {
+    const err = new Error("missing --workspace (or MAR21_WORKSPACE)");
+    (err as Error & { exitCode?: number }).exitCode = 2;
+    throw err;
+  }
+
+  const wsRoot = workspaceRoot(repoRoot, workspaceId);
+  if (!fs.existsSync(wsRoot) || !fs.statSync(wsRoot).isDirectory()) {
+    const err = new Error(`workspace not found: ${workspaceId} (${wsRoot})`);
+    (err as Error & { exitCode?: number }).exitCode = 10;
+    throw err;
+  }
+
+  const profileId = (opts.profile ?? opts.cadence).trim();
+  const profile = loadProfile(profilePathFor(wsRoot, profileId));
+
+  const runs: RunSummary[] = [];
+  for (const step of profile.steps) {
+    runs.push(
+      runPlan(step.workflowId, {
+        workspace: workspaceId,
+        mode: opts.mode ?? step.mode,
+        since: opts.since ?? step.since,
+        dryRun: Boolean(opts.dryRun)
+      })
+    );
+  }
+
+  return { cadence: opts.cadence, workspace: workspaceId, profileId: profile.id || profileId, runs };
+}
+


### PR DESCRIPTION
Closes #13.

## What
- Adds `mar21 run daily|weekly|monthly` (v0.1) that reads `workspaces/<ws>/profiles/<cadence>.yaml` and creates one run per profile step.
- Adds `--profile <id>` to select a different profile file.
- Aligns CLI workspace selection with the spec: `MAR21_WORKSPACE` is used when `--workspace` is omitted (plan/apply/run).

## Test
- `pnpm -C packages/cli build`
- `mar21 init --workspace demo --force`
- Create `workspaces/demo/profiles/weekly.yaml`, then:
  - `MAR21_WORKSPACE=demo mar21 run weekly --json`
