### PR TITLE
Fix: reliable --json output (await actions/flush)

### DIFF
--- a/packages/cli/src/apply-engine.ts
+++ b/packages/cli/src/apply-engine.ts
@@ -390,6 +390,7 @@ export async function applyRunChangeset(opts: ApplyOptions): Promise<{ summary: 
   const results: ApplyResult[] = [];
 
   const promptTo = opts.json ? process.stderr : process.stdout;
+  const canPrompt = Boolean(process.stdin.isTTY);
 
   for (const op of cs.ops ?? []) {
     if (alreadyApplied(applyState, op)) {
@@ -401,14 +402,20 @@ export async function applyRunChangeset(opts: ApplyOptions): Promise<{ summary: 
     try {
       let approved = true;
       if (op.requiresApproval) {
-        if (opts.yes) approved = true;
-        else approved = await promptApprove(op, promptTo);
+        if (opts.yes) {
+          approved = true;
+        } else if (!canPrompt) {
+          approved = false;
+        } else {
+          approved = await promptApprove(op, promptTo);
+        }
 
         approvals.push({
           opId: op.id,
           decision: approved ? "approved" : "rejected",
           decidedAt: nowIso(),
-          by: opts.yes ? "cli" : "operator"
+          by: opts.yes ? "cli" : canPrompt ? "operator" : "cli",
+          note: !opts.yes && !canPrompt ? "non_interactive: auto-rejected (use --yes for CI)" : undefined
         });
         writeApprovals(runDir, approvals);
         appendLogLine(runDir, {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,15 @@ process.on("uncaughtException", (err) => {
 
 const program = new Command();
 
+async function writeStdoutLine(line: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    process.stdout.write(line.endsWith("\n") ? line : `${line}\n`, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
 program
   .name("mar21")
   .description("AI-native Marketing Operating System (boilerplate)")
@@ -52,7 +61,7 @@ program
   .option("--dry-run", "Never apply writes (still produces ChangeSet)", false)
   .option("--json", "Print machine-readable run summary", false)
   .action(
-    (
+    async (
       workflowId: string,
       opts: {
         workspace?: string;
@@ -75,7 +84,7 @@ program
     });
 
     if (opts.json) {
-      process.stdout.write(`${JSON.stringify(summary)}\n`);
+      await writeStdoutLine(JSON.stringify(summary));
       return;
     }
     console.log(`✓ run created: ${summary.runId}`);
@@ -94,7 +103,7 @@ program
   .option("--dry-run", "Never apply writes (still produces ChangeSet)", false)
   .option("--json", "Print machine-readable run summary", false)
   .action(
-    (
+    async (
       cadence: string,
       opts: {
         workspace?: string;
@@ -126,7 +135,7 @@ program
       });
 
       if (opts.json) {
-        process.stdout.write(`${JSON.stringify(summary)}\n`);
+        await writeStdoutLine(JSON.stringify(summary));
         return;
       }
 
@@ -159,8 +168,9 @@ program
       });
 
       if (opts.json) {
-        process.stdout.write(`${JSON.stringify(summary)}\n`);
-        process.exit(exitCode);
+        await writeStdoutLine(JSON.stringify(summary));
+        process.exitCode = exitCode;
+        return;
       }
 
       const failed = summary.results.filter((r) => r.status === "failed");
@@ -170,8 +180,8 @@ program
       if (failed.length) console.log(`  - failed ops: ${failed.length}`);
       if (skipped.length) console.log(`  - skipped ops: ${skipped.length}`);
       if (rejected.length) console.log(`  - rejected ops: ${rejected.length}`);
-      process.exit(exitCode);
+      process.exitCode = exitCode;
     }
   );
 
-program.parse(process.argv);
+await program.parseAsync(process.argv);


### PR DESCRIPTION
Closes #19.

## Fix
- Ensures `--json` output is actually written before process exit:
  - Actions with async work are now awaited (`parseAsync`).
  - JSON writes are awaited via the `stdout.write` callback.
- Avoids hanging prompts in non-interactive mode: when stdin is not a TTY and approvals are required, ops are auto-rejected unless `--yes` is set.

## Test
- `mar21 plan ... --json > out.json` produces non-empty JSON.
- `mar21 apply ... --json > out.json` produces non-empty JSON.
