### PR TITLE
Fix: graceful YAML parse errors (exit 11)

### DIFF
--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -35,7 +35,14 @@ function loadJsonFile(filePath: string): unknown {
 
 function loadYamlFile(filePath: string): unknown {
   const raw = fs.readFileSync(filePath, "utf-8");
-  return YAML.parse(raw);
+  try {
+    return YAML.parse(raw);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const err = new Error(`invalid YAML: ${filePath}: ${msg}`) as Error & { exitCode?: number };
+    err.exitCode = 11;
+    throw err;
+  }
 }
 
 function buildAjv(schemaDir: string): Ajv2020Instance {

--- a/packages/cli/src/workspace.ts
+++ b/packages/cli/src/workspace.ts
@@ -44,7 +44,15 @@ export function requireWorkspaceRoot(repoRoot: string, workspaceId: string): str
 }
 
 export function readYamlFile(filePath: string): unknown {
-  return YAML.parse(fs.readFileSync(filePath, "utf-8"));
+  const raw = fs.readFileSync(filePath, "utf-8");
+  try {
+    return YAML.parse(raw);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const err = new Error(`invalid YAML: ${filePath}: ${msg}`) as Error & { exitCode?: number };
+    err.exitCode = 11;
+    throw err;
+  }
 }
 
 export function writeYamlFile(filePath: string, data: unknown): void {


### PR DESCRIPTION
Closes #28.

## Fix
- Wraps YAML parsing with a concise error message that includes the file path.
- Uses exit code `11` (schema/validation failures) instead of crashing with a stack trace.

## Coverage
- `readYamlFile(...)` (workspace artifacts like `changeset.yaml`, context, todos, etc.)
- CLI example validation YAML loader
