### PR TITLE
Apply: add --fail-on-reject for CI

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -15,7 +15,7 @@ mar21 report <cadence|workflowId> --workspace <id> [--since <duration>] [--json]
 mar21 run daily|weekly|monthly --workspace <id> [--profile <profileId>] [--mode <mode>] [--dry-run] [--json]
 mar21 autopilot start --workspace <id> --profile <profileId> [--mode <mode>] [--dry-run] [--foreground]
 
-mar21 apply <runId> --workspace <id> [--yes] [--json]
+mar21 apply <runId> --workspace <id> [--yes] [--fail-on-reject] [--json]
 ```
 
 ### Optional task convenience commands (v1)
@@ -89,7 +89,9 @@ Prompt:
 If rejected, the CLI must:
 - record a rejection entry in `approvals.json`
 - skip the op
-- continue to the next op (unless `--fail-on-reject` is introduced later; not in v1)
+- continue to the next op
+
+If `--fail-on-reject` is set, the CLI must exit non-zero if any op is rejected.
 
 ### Sensitive reads exceeding caps (Drive exports/downloads)
 If a run would exceed caps (e.g. `maxDownloads`, `maxFileSizeMB`):

--- a/packages/cli/src/apply-engine.ts
+++ b/packages/cli/src/apply-engine.ts
@@ -44,6 +44,7 @@ export type ApplyOptions = {
   runId: string;
   yes?: boolean;
   json?: boolean;
+  failOnReject?: boolean;
 };
 
 export type ApplySummary = {
@@ -456,6 +457,9 @@ export async function applyRunChangeset(opts: ApplyOptions): Promise<{ summary: 
   appendLogLine(runDir, { event: "apply.finished", runId: opts.runId });
 
   const hadFailures = results.some((r) => r.status === "failed");
+  const hadRejections = results.some((r) => r.status === "rejected");
   const summary: ApplySummary = { runId: opts.runId, workspace: workspaceId, results };
-  return { summary, exitCode: hadFailures ? 30 : 0 };
+  if (hadFailures) return { summary, exitCode: 30 };
+  if (opts.failOnReject && hadRejections) return { summary, exitCode: 30 };
+  return { summary, exitCode: 0 };
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -150,6 +150,7 @@ program
   .argument("<runId>", "Run id")
   .option("--workspace <id>", "Workspace id")
   .option("--yes", "Auto-approve all required approvals", false)
+  .option("--fail-on-reject", "Exit non-zero if any op is rejected", false)
   .option("--json", "Print machine-readable apply summary", false)
   .action(
     async (
@@ -157,6 +158,7 @@ program
       opts: {
         workspace?: string;
         yes?: boolean;
+        failOnReject?: boolean;
         json?: boolean;
       }
     ) => {
@@ -164,7 +166,8 @@ program
         workspace: opts.workspace,
         runId,
         yes: Boolean(opts.yes),
-        json: Boolean(opts.json)
+        json: Boolean(opts.json),
+        failOnReject: Boolean(opts.failOnReject)
       });
 
       if (opts.json) {


### PR DESCRIPTION
Closes #27.

## What
- Adds `--fail-on-reject` to `mar21 apply` so CI/autopilot can fail when any op is rejected.
- When set, rejections lead to exit code `30` (apply failed) while still producing logs + `approvals.json`.

## Docs
- Updates `docs/CLI.md` to include `--fail-on-reject`.
