### PR TITLE
v0.1: analyze + report commands

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import process from "node:process";
 import { applyRunChangeset } from "./apply-engine.js";
 import { initWorkspace } from "./init.js";
 import { runCadence } from "./run-cadence.js";
-import { runPlan } from "./run-engine.js";
+import { runAnalyze, runPlan, runReport } from "./run-engine.js";
 import { validateExamples } from "./validate.js";
 
 process.on("uncaughtException", (err) => {
@@ -75,13 +75,13 @@ program
       opts.mode === "advisory" || opts.mode === "supervised" || opts.mode === "autonomous"
         ? opts.mode
         : undefined;
-    const summary = runPlan(workflowId, {
-      workspace: opts.workspace,
-      mode,
-      since: opts.since,
-      dryRun: Boolean(opts.dryRun),
-      json: Boolean(opts.json)
-    });
+      const summary = runPlan(workflowId, {
+        workspace: opts.workspace,
+        mode,
+        since: opts.since,
+        dryRun: Boolean(opts.dryRun),
+        json: Boolean(opts.json)
+      });
 
     if (opts.json) {
       await writeStdoutLine(JSON.stringify(summary));
@@ -89,6 +89,78 @@ program
     }
     console.log(`✓ run created: ${summary.runId}`);
     console.log(`  - ${summary.paths.runDir}`);
+    }
+  );
+
+program
+  .command("analyze")
+  .description("Run an analysis scope (v0.1: artifacts-only)")
+  .argument("<scope>", "Scope (e.g. seo, ads, crm)")
+  .option("--workspace <id>", "Workspace id")
+  .option("--mode <mode>", "advisory|supervised|autonomous")
+  .option("--since <duration>", "ISO 8601 duration, e.g. P7D or P28D")
+  .option("--dry-run", "Never apply writes (still produces ChangeSet)", false)
+  .option("--json", "Print machine-readable run summary", false)
+  .action(
+    async (
+      scope: string,
+      opts: {
+        workspace?: string;
+        mode?: string;
+        since?: string;
+        dryRun?: boolean;
+        json?: boolean;
+      }
+    ) => {
+      const mode =
+        opts.mode === "advisory" || opts.mode === "supervised" || opts.mode === "autonomous"
+          ? opts.mode
+          : undefined;
+      const summary = runAnalyze(scope, {
+        workspace: opts.workspace,
+        mode,
+        since: opts.since,
+        dryRun: Boolean(opts.dryRun),
+        json: Boolean(opts.json)
+      });
+
+      if (opts.json) {
+        await writeStdoutLine(JSON.stringify(summary));
+        return;
+      }
+      console.log(`✓ run created: ${summary.runId}`);
+      console.log(`  - ${summary.paths.runDir}`);
+    }
+  );
+
+program
+  .command("report")
+  .description("Generate a report (v0.1: artifacts-only)")
+  .argument("<cadenceOrWorkflowId>", "Cadence (daily|weekly|monthly) or workflowId")
+  .option("--workspace <id>", "Workspace id")
+  .option("--since <duration>", "ISO 8601 duration, e.g. P7D or P28D")
+  .option("--json", "Print machine-readable run summary", false)
+  .action(
+    async (
+      cadenceOrWorkflowId: string,
+      opts: {
+        workspace?: string;
+        since?: string;
+        json?: boolean;
+      }
+    ) => {
+      const summary = runReport(cadenceOrWorkflowId, {
+        workspace: opts.workspace,
+        since: opts.since,
+        json: Boolean(opts.json)
+      });
+
+      if (opts.json) {
+        await writeStdoutLine(JSON.stringify(summary));
+        return;
+      }
+      console.log(`✓ run created: ${summary.runId}`);
+      console.log(`  - ${summary.paths.runDir}`);
     }
   );
 

--- a/packages/cli/src/run-engine.ts
+++ b/packages/cli/src/run-engine.ts
@@ -27,6 +27,7 @@ export type PlanCommandOptions = {
   since?: string;
   dryRun?: boolean;
   json?: boolean;
+  params?: Record<string, unknown>;
 };
 
 function repoRootFromCwd(): string {
@@ -223,6 +224,27 @@ function logsLine(event: Record<string, unknown>): string {
   return `${JSON.stringify({ ts: nowIso(), level: "info", ...event })}\n`;
 }
 
+function writeRequestYaml(args: {
+  inputsDir: string;
+  workflowId: string;
+  workspaceId: string;
+  mode: Mode;
+  since: string;
+  params?: Record<string, unknown>;
+}): void {
+  writeText(
+    path.join(args.inputsDir, "request.yaml"),
+    YAML.stringify({
+      apiVersion: "mar21/request-v1",
+      workflowId: args.workflowId,
+      workspace: args.workspaceId,
+      mode: args.mode,
+      since: args.since,
+      params: args.params ?? {}
+    })
+  );
+}
+
 export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSummary {
   const repoRoot = repoRootFromCwd();
   const workspaceId = resolveWorkspaceId(opts.workspace);
@@ -267,17 +289,7 @@ export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSum
   const since = opts.since ?? "P28D";
 
   fs.copyFileSync(contextPath, path.join(inputsDir, "context.snapshot.yaml"));
-  writeText(
-    path.join(inputsDir, "request.yaml"),
-    YAML.stringify({
-      apiVersion: "mar21/request-v1",
-      workflowId,
-      workspace: workspaceId,
-      mode,
-      since,
-      params: {}
-    })
-  );
+  writeRequestYaml({ inputsDir, workflowId, workspaceId, mode, since, params: opts.params });
 
   writeText(path.join(outputsDir, "plan.md"), planTemplate(workflowId));
   writeText(path.join(outputsDir, "report.md"), reportTemplate(workflowId));
@@ -354,4 +366,22 @@ export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSum
       changeset: path.relative(repoRoot, path.join(runDir, "changeset.yaml"))
     }
   };
+}
+
+export function runAnalyze(scopeRaw: string, opts: PlanCommandOptions): RunSummary {
+  const scope = scopeRaw.trim();
+  const workflowId = `analyze_${slugifyWorkflowId(scope)}`;
+  return runPlan(workflowId, {
+    ...opts,
+    params: { ...(opts.params ?? {}), scope }
+  });
+}
+
+export function runReport(argRaw: string, opts: PlanCommandOptions): RunSummary {
+  const arg = argRaw.trim();
+  const workflowId = `report_${slugifyWorkflowId(arg)}`;
+  return runPlan(workflowId, {
+    ...opts,
+    params: { ...(opts.params ?? {}), cadenceOrWorkflowId: arg }
+  });
 }


### PR DESCRIPTION
Closes #31.

## What
- Adds `mar21 analyze <scope>` and `mar21 report <cadence|workflowId>` (v0.1: artifacts-only).

## Notes
- Both commands create canonical runs (same required artifacts as `plan`).
- `inputs/request.yaml` records `scope` and `cadenceOrWorkflowId` under `params`.
- Supports `MAR21_WORKSPACE` fallback when `--workspace` is omitted.
