### PR TITLE
v0.1: autopilot start (foreground loop)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -126,3 +126,13 @@ When `--json` is set, stdout must include a single JSON object:
   }
 }
 ```
+
+## Autopilot (v0.1 behavior)
+In v0.1, `mar21 autopilot start` is a **foreground-only loop runner**:
+- It loads `workspaces/<ws>/profiles/<profileId>.yaml` and executes all steps immediately (one run per step).
+- It then sleeps and repeats. The sleep interval is a heuristic derived from `profileId`:
+  - `daily` → 24h
+  - `weekly` → 7d
+  - `monthly` → 30d
+  - otherwise → 24h
+- Background/daemon mode is not implemented in v0.1.

--- a/packages/cli/src/autopilot.ts
+++ b/packages/cli/src/autopilot.ts
@@ -1,0 +1,95 @@
+import process from "node:process";
+import { loadProfile, profilePathFor } from "./profile.js";
+import { runPlan, RunSummary } from "./run-engine.js";
+import { Mode, resolveWorkspaceId, workspaceRoot } from "./workspace.js";
+import fs from "node:fs";
+
+export type AutopilotOptions = {
+  workspace?: string;
+  profileId: string;
+  mode?: Mode;
+  dryRun?: boolean;
+  foreground?: boolean;
+};
+
+function repoRootFromCwd(): string {
+  return process.cwd();
+}
+
+function intervalMsForProfile(profileId: string): number {
+  const override = process.env.MAR21_AUTOPILOT_INTERVAL_MS;
+  if (override) {
+    const n = Number(override);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  const id = profileId.toLowerCase();
+  if (id === "daily") return 24 * 60 * 60 * 1000;
+  if (id === "weekly") return 7 * 24 * 60 * 60 * 1000;
+  if (id === "monthly") return 30 * 24 * 60 * 60 * 1000;
+  return 24 * 60 * 60 * 1000;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function autopilotStart(opts: AutopilotOptions): Promise<void> {
+  const repoRoot = repoRootFromCwd();
+  const workspaceId = resolveWorkspaceId(opts.workspace);
+  if (!workspaceId) {
+    const err = new Error("missing --workspace (or MAR21_WORKSPACE)");
+    (err as Error & { exitCode?: number }).exitCode = 2;
+    throw err;
+  }
+
+  const wsRoot = workspaceRoot(repoRoot, workspaceId);
+  if (!fs.existsSync(wsRoot) || !fs.statSync(wsRoot).isDirectory()) {
+    const err = new Error(`workspace not found: ${workspaceId} (${wsRoot})`);
+    (err as Error & { exitCode?: number }).exitCode = 10;
+    throw err;
+  }
+
+  if (!opts.foreground) {
+    const err = new Error("background mode not implemented (use --foreground)");
+    (err as Error & { exitCode?: number }).exitCode = 2;
+    throw err;
+  }
+
+  const profileId = opts.profileId.trim();
+  const profile = loadProfile(profilePathFor(wsRoot, profileId));
+  const intervalMs = intervalMsForProfile(profileId);
+
+  process.stdout.write(`autopilot: started (workspace=${workspaceId}, profile=${profileId})\n`);
+  process.stdout.write(`autopilot: interval=${Math.round(intervalMs / 1000)}s (v0.1 heuristic)\n`);
+
+  let shouldStop = false;
+  process.on("SIGINT", () => {
+    shouldStop = true;
+  });
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (shouldStop) {
+      process.stdout.write("autopilot: stopped\n");
+      return;
+    }
+    const startedAt = new Date().toISOString();
+    process.stdout.write(`\nautopilot: tick ${startedAt}\n`);
+
+    const runs: RunSummary[] = [];
+    for (const step of profile.steps) {
+      runs.push(
+        runPlan(step.workflowId, {
+          workspace: workspaceId,
+          mode: opts.mode ?? step.mode,
+          since: step.since,
+          dryRun: Boolean(opts.dryRun)
+        })
+      );
+    }
+
+    for (const r of runs) process.stdout.write(`- ${r.runId}\n`);
+    process.stdout.write(`autopilot: sleep\n`);
+    await sleep(intervalMs);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import process from "node:process";
 import { applyRunChangeset } from "./apply-engine.js";
+import { autopilotStart } from "./autopilot.js";
 import { initWorkspace } from "./init.js";
 import { runCadence } from "./run-cadence.js";
 import { runAnalyze, runPlan, runReport } from "./run-engine.js";
@@ -213,6 +214,31 @@ program
 
       console.log(`✓ cadence run: ${summary.cadence} (${summary.profileId})`);
       for (const r of summary.runs) console.log(`  - ${r.runId}`);
+    }
+  );
+
+program
+  .command("autopilot")
+  .description("Run a scheduled loop (v0.1: foreground only)")
+  .command("start")
+  .requiredOption("--profile <profileId>", "Profile id (workspaces/<ws>/profiles/<id>.yaml)")
+  .option("--workspace <id>", "Workspace id")
+  .option("--mode <mode>", "advisory|supervised|autonomous")
+  .option("--dry-run", "Never apply writes (still produces ChangeSet)", false)
+  .option("--foreground", "Run in foreground (required in v0.1)", false)
+  .action(
+    async (opts: { profile: string; workspace?: string; mode?: string; dryRun?: boolean; foreground?: boolean }) => {
+      const mode =
+        opts.mode === "advisory" || opts.mode === "supervised" || opts.mode === "autonomous"
+          ? opts.mode
+          : undefined;
+      await autopilotStart({
+        workspace: opts.workspace,
+        profileId: opts.profile,
+        mode,
+        dryRun: Boolean(opts.dryRun),
+        foreground: Boolean(opts.foreground)
+      });
     }
   );
 


### PR DESCRIPTION
Closes #32.

## What
- Adds `mar21 autopilot start --profile <id> --foreground` (v0.1) as a simple loop runner.
- Executes the profile steps immediately, then sleeps and repeats (interval heuristic from profile id).

## Docs
- Documents the v0.1 autopilot behavior in `docs/CLI.md`.
