### PR TITLE
Autopilot: add max ticks env for CI

### DIFF
--- a/packages/cli/src/autopilot.ts
+++ b/packages/cli/src/autopilot.ts
@@ -58,14 +58,22 @@ export async function autopilotStart(opts: AutopilotOptions): Promise<void> {
   const profileId = opts.profileId.trim();
   const profile = loadProfile(profilePathFor(wsRoot, profileId));
   const intervalMs = intervalMsForProfile(profileId);
+  const maxTicksRaw = process.env.MAR21_AUTOPILOT_MAX_TICKS;
+  const maxTicks =
+    maxTicksRaw && Number.isFinite(Number(maxTicksRaw)) && Number(maxTicksRaw) > 0
+      ? Math.floor(Number(maxTicksRaw))
+      : null;
 
   process.stdout.write(`autopilot: started (workspace=${workspaceId}, profile=${profileId})\n`);
   process.stdout.write(`autopilot: interval=${Math.round(intervalMs / 1000)}s (v0.1 heuristic)\n`);
+  if (maxTicks !== null) process.stdout.write(`autopilot: maxTicks=${maxTicks}\n`);
 
   let shouldStop = false;
   process.on("SIGINT", () => {
     shouldStop = true;
   });
+
+  let ticks = 0;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -89,6 +97,12 @@ export async function autopilotStart(opts: AutopilotOptions): Promise<void> {
     }
 
     for (const r of runs) process.stdout.write(`- ${r.runId}\n`);
+    ticks += 1;
+    if (maxTicks !== null && ticks >= maxTicks) {
+      process.stdout.write("autopilot: done\n");
+      return;
+    }
+
     process.stdout.write(`autopilot: sleep\n`);
     await sleep(intervalMs);
   }


### PR DESCRIPTION
Closes #36.

## What
- Adds `MAR21_AUTOPILOT_MAX_TICKS` so `mar21 autopilot start --foreground` can be tested in CI without hanging.

## Usage
- `MAR21_AUTOPILOT_MAX_TICKS=1` runs one tick then exits 0.
