### PR TITLE
Messaging: agentic marketing, you in control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # mar21
-**AI-native Marketing Operating System** — an open-source boilerplate for *one-person marketing* from GTM strategy to operational execution and reporting.
+**Marketing boilerplate for the 21st century** — an open-source foundation for **agentic marketing**, where **you stay in control**.
 
-`mar21` is not “a few automations”. It is a **repository convention + skill system + connector interfaces + CLI agent surface** that lets an operator run marketing as an **auditable engine**:
+`mar21` is not “a few automations”. It is a **repository convention + skill system + connector interfaces + CLI** that lets a growth operator/CMO run marketing as an **auditable execution engine**:
 
 - **Context-first**: persistent marketing context lives in versioned YAML (company, model, KPIs, constraints, risk).
 - **Run-based**: work happens in runs that always emit **Plan + Report + ChangeSet**.
-- **Supervised-by-default**: the agent proposes changes; you approve (or opt-in to safe autopilot).
+- **You in control**: supervised-by-default — the agent proposes changes; you approve (or opt in to safe autopilot).
 - **Connector-driven**: first-class interfaces to typical marketing tools (v1: GSC, GA4, Meta Ads, HubSpot, Shopify, WordPress, Slack, Klaviyo).
 - **Own your AI**: keep competence, memory, and decision logic in *your* repo; still leverage platform-native AI where helpful.
 - **Moving target**: this repo is designed to evolve with the space—one step at a time, with stable interfaces.

--- a/docs/MANIFESTO.md
+++ b/docs/MANIFESTO.md
@@ -1,6 +1,6 @@
 # mar21 Manifesto
 
-`mar21` is an **AI-native Marketing Operating System**: a repo-first, skill-driven way to run marketing as a **repeatable, inspectable engine**.
+`mar21` is **marketing boilerplate for the 21st century**: a repo-first, skill-driven way to run **agentic marketing** as a **repeatable, inspectable engine** — with **you in control**.
 
 This is a manifesto *and* an implementation stance. The “operating system” is not a metaphor—it's a set of conventions, contracts, and run artifacts that make marketing work **programmable** without making it **opaque**.
 

--- a/docs/SPECS.md
+++ b/docs/SPECS.md
@@ -1,6 +1,6 @@
 # mar21 Specs (Interfaces + File Formats)
 
-This document defines the **stable surface** of `mar21`. These contracts are designed to be implemented by a CLI agent and to remain stable as tools and models evolve.
+This document defines the **stable surface** of `mar21`. These contracts are designed to be implemented by a CLI/agent runtime and to remain stable as tools and models evolve — so you can run **agentic marketing** while staying **in control**.
 
 Principles:
 - **YAML for human-first config and ops**, JSON for logs/metrics

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,7 +30,7 @@ async function writeStdoutLine(line: string): Promise<void> {
 
 program
   .name("mar21")
-  .description("AI-native Marketing Operating System (boilerplate)")
+  .description("Marketing boilerplate for the 21st century (agentic, you in control)")
   .version("0.1.0");
 
 program
@@ -45,7 +45,7 @@ program
 
 program
   .command("validate")
-  .description("Validate artifacts against schemas (v0.1: stub)")
+  .description("Validate artifacts against schemas (v0.1)")
   .option("--examples", "Validate examples/", false)
   .action((opts: { examples?: boolean }) => {
     if (opts.examples) process.exit(validateExamples());


### PR DESCRIPTION
Closes #39.

- Aligns messaging across `README.md`, CLI description, `docs/MANIFESTO.md`, and `docs/SPECS.md`.
- Frames mar21 as “marketing boilerplate for the 21st century” and “agentic marketing — you in control”.
