### PR TITLE
Init: stack/connectors secrets template

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Docs are the product for v0: the manifesto + the decision-complete interfaces yo
 This repo specifies an opinionated CLI, even before code exists:
 
 ```bash
-mar21 init --workspace acme
+mar21 init --workspace acme --stack default
 mar21 plan gtm --workspace acme
 
 mar21 analyze week --workspace acme

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -6,7 +6,7 @@ This document defines the **exact** CLI surface and UX expectations. Implementer
 
 ### Core verbs
 ```
-mar21 init --workspace <id> [--force]
+mar21 init --workspace <id> [--stack <preset>] [--connectors <list>] [--force]
 
 mar21 plan <workflowId> --workspace <id> [--mode <mode>] [--since <duration>] [--dry-run] [--json]
 mar21 analyze <scope> --workspace <id> [--mode <mode>] [--since <duration>] [--dry-run] [--json]
@@ -39,6 +39,10 @@ mar21 crm plan <workflowId> ...
 ## Global flags and precedence
 - `--workspace <id>` selects `workspaces/<id>/`.
 - `MAR21_WORKSPACE` is used only if `--workspace` is absent.
+- `mar21 init` stack selection:
+  - `--connectors <list>` (comma-separated ids) wins over `--stack`.
+  - `--stack <preset>` defaults to `default`.
+  - Supported presets in v0.1: `default`, `content_engine`, `paid_growth`, `lifecycle`.
 - `--mode advisory|supervised|autonomous` overrides:
   - `constraints.autonomy.defaultMode` in the context, and
   - any profile step mode (unless a step explicitly pins a higher-safety mode).

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,11 +37,26 @@ program
   .command("init")
   .description("Initialize a workspace skeleton (v0.1)")
   .option("--workspace <id>", "Workspace id")
+  .option(
+    "--stack <preset>",
+    "Stack preset (default: default). Examples: default, content_engine, paid_growth, lifecycle"
+  )
+  .option(
+    "--connectors <list>",
+    "Comma-separated connector ids (overrides --stack), e.g. gsc,ga4,wordpress,slack,gdrive,ahrefs"
+  )
   .option("--force", "Overwrite if exists", false)
-  .action((opts: { workspace?: string; force?: boolean }) => {
-    const res = initWorkspace({ workspace: opts.workspace, force: opts.force });
-    console.log(`✓ workspace initialized: ${res.workspace} (${res.root})`);
-  });
+  .action(
+    (opts: { workspace?: string; stack?: string; connectors?: string; force?: boolean }) => {
+      const res = initWorkspace({
+        workspace: opts.workspace,
+        stack: opts.stack,
+        connectors: opts.connectors,
+        force: opts.force
+      });
+      console.log(`✓ workspace initialized: ${res.workspace} (${res.root})`);
+    }
+  );
 
 program
   .command("validate")

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -6,15 +6,209 @@ import { ensureDir } from "./workspace.js";
 
 export type InitOptions = {
   workspace?: string;
+  stack?: string;
+  connectors?: string;
   force?: boolean;
 };
 
-function repoRootFromCwd(): string {
-  return process.cwd();
+function findRepoRootFromCwd(): string | null {
+  let dir = process.cwd();
+  for (let i = 0; i < 25; i += 1) {
+    const packagesDir = path.join(dir, "packages");
+    const schemasDir = path.join(dir, "schemas");
+    const docsDir = path.join(dir, "docs");
+    if (fs.existsSync(packagesDir) && fs.existsSync(schemasDir) && fs.existsSync(docsDir)) return dir;
+
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
 }
 
 function validateWorkspaceId(id: string): boolean {
   return /^[a-z0-9][a-z0-9-]{1,31}$/.test(id);
+}
+
+type ConnectorId =
+  | "gsc"
+  | "ga4"
+  | "meta_ads"
+  | "hubspot"
+  | "shopify"
+  | "wordpress"
+  | "slack"
+  | "klaviyo"
+  | "gdrive"
+  | "ahrefs";
+
+const CONNECTOR_ORDER: ConnectorId[] = [
+  "gsc",
+  "ga4",
+  "meta_ads",
+  "hubspot",
+  "shopify",
+  "wordpress",
+  "slack",
+  "klaviyo",
+  "gdrive",
+  "ahrefs"
+];
+
+const STACK_PRESETS: Record<string, ConnectorId[]> = {
+  default: ["gsc", "ga4", "meta_ads", "hubspot", "shopify", "wordpress", "slack", "klaviyo", "gdrive"],
+  content_engine: ["gsc", "ga4", "wordpress", "slack", "gdrive", "ahrefs"],
+  paid_growth: ["ga4", "meta_ads", "slack"],
+  lifecycle: ["ga4", "shopify", "klaviyo", "slack"]
+};
+
+function parseConnectors(raw: string): ConnectorId[] {
+  const parts = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const unknown: string[] = [];
+  const selected = new Set<ConnectorId>();
+  for (const p of parts) {
+    if (!/^[a-z0-9_]+$/.test(p)) {
+      unknown.push(p);
+      continue;
+    }
+    if (!CONNECTOR_ORDER.includes(p as ConnectorId)) unknown.push(p);
+    else selected.add(p as ConnectorId);
+  }
+
+  if (unknown.length > 0) {
+    const err = new Error(
+      `unknown connector id(s): ${unknown.join(", ")} (supported: ${CONNECTOR_ORDER.join(", ")})`
+    );
+    (err as Error & { exitCode?: number }).exitCode = 2;
+    throw err;
+  }
+
+  return CONNECTOR_ORDER.filter((c) => selected.has(c));
+}
+
+function resolveConnectorSelection(opts: InitOptions): ConnectorId[] {
+  if (opts.connectors && opts.connectors.trim().length > 0) return parseConnectors(opts.connectors);
+
+  const preset = (opts.stack?.trim() || "default").toLowerCase();
+  const selected = STACK_PRESETS[preset];
+  if (!selected) {
+    const err = new Error(
+      `unknown stack preset: ${preset} (supported: ${Object.keys(STACK_PRESETS).join(", ")})`
+    );
+    (err as Error & { exitCode?: number }).exitCode = 2;
+    throw err;
+  }
+  return CONNECTOR_ORDER.filter((c) => selected.includes(c));
+}
+
+function envTemplateForConnectors(workspaceId: string, connectors: ConnectorId[]): string {
+  const lines: string[] = [];
+  lines.push("# mar21 workspace secrets (never commit)");
+  lines.push("# Put secrets here and load them into your shell before running mar21.");
+  lines.push("# Example:");
+  lines.push("#   set -a; source secrets/.env; set +a");
+  lines.push("");
+  lines.push("# Workspace (optional convenience)");
+  lines.push(`# MAR21_WORKSPACE=${workspaceId}`);
+  lines.push("");
+
+  const has = (id: ConnectorId) => connectors.includes(id);
+
+  if (has("gsc")) {
+    lines.push("## Google Search Console (gsc)");
+    lines.push("# OAuth app: Google Cloud Console -> APIs & Services -> Credentials");
+    lines.push("MAR21_GSC_CLIENT_ID=");
+    lines.push("MAR21_GSC_CLIENT_SECRET=");
+    lines.push("MAR21_GSC_REFRESH_TOKEN=");
+    lines.push("# Optional convenience:");
+    lines.push("# MAR21_GSC_SITE_URL=https://example.com/");
+    lines.push("");
+  }
+
+  if (has("ga4")) {
+    lines.push("## Google Analytics 4 (ga4)");
+    lines.push("# OAuth app: Google Cloud Console -> APIs & Services -> Credentials");
+    lines.push("MAR21_GA4_CLIENT_ID=");
+    lines.push("MAR21_GA4_CLIENT_SECRET=");
+    lines.push("MAR21_GA4_REFRESH_TOKEN=");
+    lines.push("# Optional convenience:");
+    lines.push("# MAR21_GA4_PROPERTY_ID=123456789");
+    lines.push("");
+  }
+
+  if (has("meta_ads")) {
+    lines.push("## Meta Ads (meta_ads)");
+    lines.push("# Create a long-lived access token with the required permissions (Meta for Developers).");
+    lines.push("MAR21_META_ADS_ACCESS_TOKEN=");
+    lines.push("MAR21_META_ADS_ACCOUNT_ID=");
+    lines.push("");
+  }
+
+  if (has("hubspot")) {
+    lines.push("## HubSpot (hubspot)");
+    lines.push("# Create a Private App token in HubSpot.");
+    lines.push("MAR21_HUBSPOT_PRIVATE_APP_TOKEN=");
+    lines.push("");
+  }
+
+  if (has("shopify")) {
+    lines.push("## Shopify (shopify)");
+    lines.push("# Create an Admin API access token for your app in Shopify.");
+    lines.push("MAR21_SHOPIFY_ACCESS_TOKEN=");
+    lines.push("# Example: your-store.myshopify.com");
+    lines.push("MAR21_SHOPIFY_STORE_DOMAIN=");
+    lines.push("");
+  }
+
+  if (has("wordpress")) {
+    lines.push("## WordPress (wordpress)");
+    lines.push("# Create an application password for a WordPress user account.");
+    lines.push("# Example: https://www.example.com");
+    lines.push("MAR21_WORDPRESS_BASE_URL=");
+    lines.push("# Format: username:application_password (draft-only writes in v0.1)");
+    lines.push("MAR21_WORDPRESS_APP_PASSWORD=");
+    lines.push("");
+  }
+
+  if (has("slack")) {
+    lines.push("## Slack (slack)");
+    lines.push("# Create a Slack app and install it to your workspace; copy the Bot User OAuth token.");
+    lines.push("MAR21_SLACK_BOT_TOKEN=");
+    lines.push("# Optional convenience:");
+    lines.push("# MAR21_SLACK_DEFAULT_CHANNEL=#marketing");
+    lines.push("");
+  }
+
+  if (has("klaviyo")) {
+    lines.push("## Klaviyo (klaviyo)");
+    lines.push("# Create a Private API key in Klaviyo.");
+    lines.push("MAR21_KLAVIYO_PRIVATE_API_KEY=");
+    lines.push("");
+  }
+
+  if (has("gdrive")) {
+    lines.push("## Google Drive (gdrive)");
+    lines.push("# OAuth app: Google Cloud Console -> APIs & Services -> Credentials");
+    lines.push("MAR21_GDRIVE_CLIENT_ID=");
+    lines.push("MAR21_GDRIVE_CLIENT_SECRET=");
+    lines.push("MAR21_GDRIVE_REFRESH_TOKEN=");
+    lines.push("");
+  }
+
+  if (has("ahrefs")) {
+    lines.push("## Ahrefs (ahrefs) — optional / experimental (often via MCP)");
+    lines.push("# If using Ahrefs API directly:");
+    lines.push("MAR21_AHREFS_API_KEY=");
+    lines.push("# If using an MCP server or gateway, document its URL here:");
+    lines.push("# MAR21_AHREFS_MCP_URL=http://localhost:port");
+    lines.push("");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
 }
 
 export function initWorkspace(opts: InitOptions): { workspace: string; root: string } {
@@ -32,7 +226,7 @@ export function initWorkspace(opts: InitOptions): { workspace: string; root: str
     throw err;
   }
 
-  const repoRoot = repoRootFromCwd();
+  const repoRoot = findRepoRootFromCwd() ?? process.cwd();
   const wsRoot = path.join(repoRoot, "workspaces", workspaceId);
 
   if (fs.existsSync(wsRoot)) {
@@ -102,12 +296,9 @@ export function initWorkspace(opts: InitOptions): { workspace: string; root: str
   }
 
   const secretsEnvPath = path.join(wsRoot, "secrets", ".env");
-  if (!fs.existsSync(secretsEnvPath)) {
-    fs.writeFileSync(
-      secretsEnvPath,
-      `# mar21 workspace secrets (never commit)\n# Example:\n# GSC_CLIENT_ID=\n# GSC_CLIENT_SECRET=\n`,
-      "utf-8"
-    );
+  if (!fs.existsSync(secretsEnvPath) || opts.force) {
+    const connectors = resolveConnectorSelection(opts);
+    fs.writeFileSync(secretsEnvPath, envTemplateForConnectors(workspaceId, connectors), "utf-8");
   }
 
   for (const name of ["learnings.yaml", "winners.yaml", "losers.yaml", "exclusions.yaml"] as const) {
@@ -117,4 +308,3 @@ export function initWorkspace(opts: InitOptions): { workspace: string; root: str
 
   return { workspace: workspaceId, root: path.relative(repoRoot, wsRoot) };
 }
-


### PR DESCRIPTION
Closes #43.

What changed
- `mar21 init` accepts `--stack <preset>` and `--connectors <csv>`.
- Generates `workspaces/<id>/secrets/.env` with only the selected connector blocks (connector docs env var names).
- `--connectors` overrides `--stack`; default stack is `default`.
- `--force` overwrites the `.env` template too.

Presets (v0.1)
- `default`: gsc, ga4, meta_ads, hubspot, shopify, wordpress, slack, klaviyo, gdrive
- `content_engine`: gsc, ga4, wordpress, slack, gdrive, ahrefs
- `paid_growth`: ga4, meta_ads, slack
- `lifecycle`: ga4, shopify, klaviyo, slack

Manual test
- `node packages/cli/dist/index.js init --workspace acme --connectors gsc,ga4,wordpress,slack,gdrive,ahrefs --force`
- `node packages/cli/dist/index.js init --workspace acme --stack default --force`
