### PR TITLE
Core: skill runtime + v0.1 execution skills

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@mar21/core": "workspace:*",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "commander": "^13.1.0",

--- a/packages/cli/src/run-engine.ts
+++ b/packages/cli/src/run-engine.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import YAML from "yaml";
+import { executeSkillPipeline, type SkillExecutionResult, type SkillStep } from "@mar21/core";
 import {
   defaultModeFromContext,
   ensureDir,
@@ -46,10 +47,12 @@ function pickRunId(runsDir: string, baseRunId: string): string {
 }
 
 function writeJson(filePath: string, data: unknown): void {
+  ensureDir(path.dirname(filePath));
   fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
 }
 
 function writeText(filePath: string, data: string): void {
+  ensureDir(path.dirname(filePath));
   fs.writeFileSync(filePath, data.endsWith("\n") ? data : `${data}\n`, "utf-8");
 }
 
@@ -224,6 +227,20 @@ function logsLine(event: Record<string, unknown>): string {
   return `${JSON.stringify({ ts: nowIso(), level: "info", ...event })}\n`;
 }
 
+function safeJoin(baseDir: string, relativePath: string): string {
+  const resolved = path.resolve(baseDir, relativePath);
+  const baseResolved = path.resolve(baseDir);
+  if (!resolved.startsWith(`${baseResolved}${path.sep}`) && resolved !== baseResolved) {
+    throw new Error(`refusing to access path outside base: ${relativePath}`);
+  }
+  return resolved;
+}
+
+function skillOutputsPath(skillId: string): string {
+  const safe = skillId.replace(/[^a-z0-9]+/gi, "_").replace(/^_+|_+$/g, "").toLowerCase();
+  return `outputs/skill_outputs/${safe}.json`;
+}
+
 function writeRequestYaml(args: {
   inputsDir: string;
   workflowId: string;
@@ -232,17 +249,15 @@ function writeRequestYaml(args: {
   since: string;
   params?: Record<string, unknown>;
 }): void {
-  writeText(
-    path.join(args.inputsDir, "request.yaml"),
-    YAML.stringify({
-      apiVersion: "mar21/request-v1",
-      workflowId: args.workflowId,
-      workspace: args.workspaceId,
-      mode: args.mode,
-      since: args.since,
-      params: args.params ?? {}
-    })
-  );
+  const req = {
+    apiVersion: "mar21/request-v1",
+    workflowId: args.workflowId,
+    workspace: args.workspaceId,
+    mode: args.mode,
+    since: args.since,
+    params: args.params ?? {}
+  };
+  writeText(path.join(args.inputsDir, "request.yaml"), YAML.stringify(req));
 }
 
 export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSummary {
@@ -294,6 +309,41 @@ export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSum
   writeText(path.join(outputsDir, "plan.md"), planTemplate(workflowId));
   writeText(path.join(outputsDir, "report.md"), reportTemplate(workflowId));
 
+  const logsPath = path.join(runDir, "logs.jsonl");
+  writeText(logsPath, logsLine({ event: "run.started", runId, workflowId, workspace: workspaceId }));
+
+  const request = {
+    apiVersion: "mar21/request-v1",
+    workflowId,
+    workspace: workspaceId,
+    mode,
+    since,
+    params: opts.params ?? {}
+  };
+
+  const ctx = {
+    repoRoot,
+    workspaceId,
+    workspaceRoot: wsRoot,
+    runId,
+    runDir,
+    inputsDir,
+    outputsDir,
+    evidenceDir,
+    mode,
+    since,
+    dryRun: Boolean(opts.dryRun),
+    context,
+    request,
+    writeText: (relativePath: string, content: string) =>
+      writeText(safeJoin(runDir, relativePath), content),
+    writeJson: (relativePath: string, data: unknown) => writeJson(safeJoin(runDir, relativePath), data),
+    writeYaml: (relativePath: string, data: unknown) =>
+      writeText(safeJoin(runDir, relativePath), YAML.stringify(data)),
+    exists: (relativePath: string) => fs.existsSync(safeJoin(runDir, relativePath)),
+    log: (event: Record<string, unknown>) => fs.appendFileSync(logsPath, logsLine(event), "utf-8")
+  } as const;
+
   const changeset: Record<string, unknown> = {
     apiVersion: "mar21/changeset-v1",
     runId,
@@ -301,6 +351,39 @@ export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSum
     mode,
     ops: []
   };
+
+  const ops: Array<Record<string, unknown>> = [];
+  const skillsExecuted: SkillExecutionResult[] = [];
+
+  const pipelineForWorkflow = (slugId: string): SkillStep[] => {
+    if (slugId === "content_brief") {
+      return [{ skillId: "content.brief_generate", inputs: { assetType: "landing_page" } }];
+    }
+    if (slugId === "landing_page_iteration") {
+      return [
+        { skillId: "content.brief_generate", inputs: { assetType: "landing_page" } },
+        { skillId: "content.wordpress_draft_create", inputs: {} },
+        { skillId: "ads.meta_creative_refresh_plan", inputs: {} }
+      ];
+    }
+    return [];
+  };
+
+  const pipeline = pipelineForWorkflow(slug);
+  if (pipeline.length > 0) {
+    try {
+      const res = executeSkillPipeline({ ctx: ctx as any, steps: pipeline });
+      for (const r of res) {
+        skillsExecuted.push(r);
+        ctx.writeJson(skillOutputsPath(r.skillId), r.outputs);
+        for (const op of r.ops) ops.push(op);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      ctx.log({ event: "run.failed", runId, error: msg });
+      throw e;
+    }
+  }
 
   if (slug === "deep_research_sparring") {
     const accessedAt = nowIso();
@@ -329,13 +412,12 @@ export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSum
       ]
     );
 
-    changeset.ops = deepResearchSparringOps();
+    for (const op of deepResearchSparringOps()) ops.push(op);
   }
 
+  (changeset as any).ops = ops;
   writeText(path.join(runDir, "changeset.yaml"), YAML.stringify(changeset));
 
-  const logsPath = path.join(runDir, "logs.jsonl");
-  writeText(logsPath, logsLine({ event: "run.started", runId, workflowId, workspace: workspaceId }));
   fs.appendFileSync(logsPath, logsLine({ event: "run.outputs", outputsDir: "outputs/" }), "utf-8");
 
   writeJson(path.join(runDir, "approvals.json"), []);
@@ -350,6 +432,7 @@ export function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): RunSum
     since,
     startedAt,
     finishedAt,
+    skillsExecuted: skillsExecuted.map((s) => s.skillId),
     connectorsUsed: [],
     writesAttempted: false
   });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,11 @@
   "scripts": {
     "build": "tsc -b tsconfig.json"
   },
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "yaml": "^2.7.0"
+  },
   "devDependencies": {
     "@types/node": "^22.13.10",
     "typescript": "^5.8.2"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,5 @@ export const MAR21 = {
   version: "0.1.0"
 } as const;
 
+export type { Mode, RunContext, SkillExecutionResult, SkillManifest, SkillStep } from "./skills/types.js";
+export { discoverSkills, executeSkillPipeline } from "./skills/runner.js";

--- a/packages/core/src/skills/runner.ts
+++ b/packages/core/src/skills/runner.ts
@@ -1,0 +1,297 @@
+import Ajv2020Import from "ajv/dist/2020.js";
+import addFormatsImport from "ajv-formats";
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import type { SkillDefinition, SkillExecutionResult, SkillManifest, SkillStep, RunContext } from "./types.js";
+
+type Ajv2020Class = typeof import("ajv/dist/2020.js").default;
+type Ajv2020Instance = InstanceType<Ajv2020Class>;
+
+const Ajv2020 = Ajv2020Import as unknown as Ajv2020Class;
+const addFormats = ((addFormatsImport as unknown as { default?: unknown }).default ??
+  addFormatsImport) as unknown as (ajv: Ajv2020Instance) => void;
+
+function walkSkillManifests(dirPath: string, out: string[]): void {
+  if (!fs.existsSync(dirPath)) return;
+  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+    const p = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) walkSkillManifests(p, out);
+    else if (entry.isFile() && entry.name === "skill.yaml") out.push(p);
+  }
+}
+
+function readYamlFile(filePath: string): unknown {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  return YAML.parse(raw);
+}
+
+function buildAjv(): Ajv2020Instance {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv;
+}
+
+function validateWithSchema(ajv: Ajv2020Instance, schema: Record<string, unknown>, instance: unknown): string[] {
+  const validate = ajv.compile(schema as any);
+  const ok = validate(instance);
+  if (ok) return [];
+  return (
+    validate.errors?.map((e) => `${e.instancePath || "/"} ${e.message ?? "invalid"}`) ?? ["invalid"]
+  );
+}
+
+function requiredString(x: unknown, field: string): string {
+  if (typeof x === "string" && x.trim().length > 0) return x;
+  throw new Error(`skill manifest missing/invalid ${field}`);
+}
+
+function asSkillManifest(doc: unknown, manifestPath: string): SkillManifest {
+  if (!doc || typeof doc !== "object") throw new Error(`invalid YAML (expected object): ${manifestPath}`);
+  const o = doc as any;
+  if (o.apiVersion !== "mar21/skill-v1") throw new Error(`unsupported apiVersion in ${manifestPath}`);
+  if (!o.inputs?.schema || typeof o.inputs.schema !== "object") throw new Error(`missing inputs.schema in ${manifestPath}`);
+  if (!o.outputs?.schema || typeof o.outputs.schema !== "object") throw new Error(`missing outputs.schema in ${manifestPath}`);
+  if (!o.artifacts?.produces || !Array.isArray(o.artifacts.produces)) throw new Error(`missing artifacts.produces in ${manifestPath}`);
+
+  return {
+    apiVersion: "mar21/skill-v1",
+    id: requiredString(o.id, "id"),
+    domain: requiredString(o.domain, "domain"),
+    description: requiredString(o.description, "description"),
+    inputs: { schema: o.inputs.schema as Record<string, unknown> },
+    outputs: { schema: o.outputs.schema as Record<string, unknown> },
+    usesConnectors: Array.isArray(o.usesConnectors) ? o.usesConnectors.map(String) : [],
+    risk: {
+      level: (o.risk?.level ?? "none") as SkillManifest["risk"]["level"],
+      writes: Boolean(o.risk?.writes ?? false)
+    },
+    artifacts: { produces: o.artifacts.produces.map(String) },
+    idempotency: {
+      strategy: (o.idempotency?.strategy ?? "snapshot_based") as SkillManifest["idempotency"]["strategy"]
+    }
+  };
+}
+
+export function discoverSkills(repoRoot: string): SkillDefinition[] {
+  const skillsDir = path.join(repoRoot, "skills");
+  const manifestPaths: string[] = [];
+  walkSkillManifests(skillsDir, manifestPaths);
+
+  const defs: SkillDefinition[] = [];
+  const byId = new Map<string, string>();
+  for (const manifestPath of manifestPaths) {
+    const doc = readYamlFile(manifestPath);
+    const manifest = asSkillManifest(doc, manifestPath);
+
+    const existing = byId.get(manifest.id);
+    if (existing) {
+      throw new Error(`duplicate skill id: ${manifest.id}\n- ${existing}\n- ${manifestPath}`);
+    }
+    byId.set(manifest.id, manifestPath);
+
+    defs.push({
+      manifestPath,
+      dir: path.dirname(manifestPath),
+      manifest
+    });
+  }
+
+  return defs.sort((a, b) => a.manifest.id.localeCompare(b.manifest.id));
+}
+
+type SkillImpl = (args: { ctx: RunContext; inputs: Record<string, unknown> }) => {
+  outputs: unknown;
+  ops?: Array<Record<string, unknown>>;
+};
+
+function opId(skillId: string, suffix: string): string {
+  const safeSkill = skillId.replace(/[^a-z0-9]+/gi, "_").replace(/^_+|_+$/g, "").toLowerCase();
+  const safeSuffix = suffix.replace(/[^a-z0-9]+/gi, "_").replace(/^_+|_+$/g, "").toLowerCase();
+  return `${safeSkill}_${safeSuffix}`.slice(0, 64);
+}
+
+const IMPLS: Record<string, SkillImpl> = {
+  "content.brief_generate": ({ ctx, inputs }) => {
+    const context = (ctx.context ?? {}) as any;
+    const companyName = String(context?.company?.name ?? "Your Company");
+    const industry = String(context?.company?.industry ?? "your category");
+    const primaryKpi = String(context?.goals?.primaryKpi ?? "primary KPI");
+    const tone = String(context?.constraints?.brandVoice?.tone ?? "professional");
+    const assetType = String((inputs as any).assetType ?? "landing_page");
+
+    const brief = {
+      apiVersion: "mar21/creative-brief-v1",
+      id: `brief_${ctx.runId}`,
+      assetType,
+      objective: `Increase ${primaryKpi} with an execution-ready asset that matches ${companyName}'s constraints.`,
+      audience: {
+        icp: context?.company?.industry ? `${industry} operators / buyers` : "Define ICP",
+        pains: ["Define top pain", "Define top objection"],
+        desiredOutcome: "Define desired outcome"
+      },
+      message: {
+        promise: "Define a single, specific promise (no vague superlatives).",
+        proof: ["Add proof points (case studies, data, process)."],
+        objections: ["List top objections and how we answer them."],
+        cta: "Define primary CTA (1)."
+      },
+      constraints: {
+        tone,
+        compliance: context?.constraints?.compliance ?? { gdpr: true },
+        doNotSay: context?.constraints?.brandVoice?.doNotSay ?? []
+      },
+      measurement: {
+        primaryKpi,
+        utmConvention: "utm_source, utm_medium, utm_campaign are required; utm_content for variants"
+      },
+      variants: {
+        system: "1 concept × 3 angles × 3 hooks (keep naming deterministic)",
+        naming: "asset::<assetType>::<concept>::<angle>::<hook>::v<NN>"
+      },
+      notes: {
+        generatedBy: "mar21 v0.1 (template skill)",
+        inputs
+      }
+    };
+
+    ctx.writeYaml("outputs/creative_brief.yaml", brief);
+
+    return {
+      outputs: {
+        briefRef: "outputs/creative_brief.yaml",
+        assetType,
+        primaryKpi
+      }
+    };
+  },
+
+  "content.wordpress_draft_create": ({ ctx, inputs }) => {
+    const context = (ctx.context ?? {}) as any;
+    const companyName = String(context?.company?.name ?? "Your Company");
+    const primaryCta = String((inputs as any).cta ?? "Book a demo");
+    const title = String((inputs as any).title ?? `Landing page draft — ${companyName}`);
+
+    const draft = `# ${title}\n\n## TL;DR\n- Outcome: <one sentence>\n- Proof: <one proof point>\n- CTA: **${primaryCta}**\n\n## The problem\n...\n\n## The approach\n...\n\n## Proof / credibility\n- Case study: ...\n- Metrics: ...\n\n## FAQs / objections\n- Q: ...\n  A: ...\n\n---\n\nCTA: ${primaryCta}\n`;
+
+    ctx.writeText("outputs/drafts/wordpress_draft_v1.md", draft);
+
+    const ops: Array<Record<string, unknown>> = [
+      {
+        id: opId("content.wordpress_draft_create", "todo_wordpress_draft"),
+        tool: "mar21",
+        operation: "mar21.todo.create",
+        risk: "low",
+        requiresApproval: true,
+        params: {
+          task: {
+            title: "Create WordPress draft from outputs/drafts/wordpress_draft_v1.md",
+            description:
+              "Draft-only in v0.1. Paste/import the markdown and keep it unpublished until measurement is set.",
+            owner: "operator",
+            priority: "p1",
+            tags: ["wordpress", "draft", "cro"],
+            evidenceRef: ["outputs/drafts/wordpress_draft_v1.md", "outputs/creative_brief.yaml"]
+          }
+        }
+      }
+    ];
+
+    return {
+      outputs: {
+        draftRef: "outputs/drafts/wordpress_draft_v1.md",
+        title,
+        cta: primaryCta
+      },
+      ops
+    };
+  },
+
+  "ads.meta_creative_refresh_plan": ({ ctx, inputs }) => {
+    const focus = String((inputs as any).focus ?? "creative fatigue + message-market fit");
+    const plan = `# Creative Refresh Plan — Meta Ads\n\n## Focus\n- ${focus}\n\n## Checklist (v0.1)\n- [ ] Pull top ads by spend and result\n- [ ] Identify fatigue signals (CTR drop, CPM rise, frequency)\n- [ ] Generate 3 new angles from the latest brief\n- [ ] Produce a 3×3 variation matrix (angle × hook)\n- [ ] Ship in draft mode; measure for 7 days\n\n## Notes\n- This is a stub skill intended to produce an execution-ready checklist + tasks.\n`;
+    ctx.writeText("outputs/creative_refresh_plan.md", plan);
+
+    const ops: Array<Record<string, unknown>> = [
+      {
+        id: opId("ads.meta_creative_refresh_plan", "todo_matrix"),
+        tool: "mar21",
+        operation: "mar21.todo.create",
+        risk: "low",
+        requiresApproval: true,
+        params: {
+          task: {
+            title: "Create 3×3 creative variation matrix for Meta Ads",
+            description:
+              "Use outputs/creative_brief.yaml to define 3 angles and 3 hooks; name assets deterministically.",
+            owner: "operator",
+            priority: "p2",
+            tags: ["meta_ads", "creative"],
+            evidenceRef: ["outputs/creative_refresh_plan.md", "outputs/creative_brief.yaml"]
+          }
+        }
+      }
+    ];
+
+    return {
+      outputs: { planRef: "outputs/creative_refresh_plan.md" },
+      ops
+    };
+  }
+};
+
+function requireImpl(skillId: string): SkillImpl {
+  const impl = IMPLS[skillId];
+  if (!impl) throw new Error(`skill not implemented in v0.1: ${skillId}`);
+  return impl;
+}
+
+export function executeSkillPipeline(args: { ctx: RunContext; steps: SkillStep[] }): SkillExecutionResult[] {
+  const defs = discoverSkills(args.ctx.repoRoot);
+  const byId = new Map<string, SkillDefinition>(defs.map((d) => [d.manifest.id, d]));
+
+  const ajv = buildAjv();
+  const results: SkillExecutionResult[] = [];
+
+  for (const step of args.steps) {
+    const def = byId.get(step.skillId);
+    if (!def) throw new Error(`skill not found: ${step.skillId} (expected skill.yaml under skills/)`);
+
+    args.ctx.log({ event: "skill.started", skillId: step.skillId });
+
+    const inputs = step.inputs ?? {};
+    const inputErrors = validateWithSchema(ajv, def.manifest.inputs.schema, inputs);
+    if (inputErrors.length > 0) {
+      throw new Error(
+        `skill input validation failed: ${step.skillId}\n- manifest: ${path.relative(args.ctx.repoRoot, def.manifestPath)}\n- ${inputErrors.join("\n- ")}`
+      );
+    }
+
+    const impl = requireImpl(step.skillId);
+    const { outputs, ops } = impl({ ctx: args.ctx, inputs });
+
+    const outputErrors = validateWithSchema(ajv, def.manifest.outputs.schema, outputs);
+    if (outputErrors.length > 0) {
+      throw new Error(
+        `skill output validation failed: ${step.skillId}\n- manifest: ${path.relative(args.ctx.repoRoot, def.manifestPath)}\n- ${outputErrors.join("\n- ")}`
+      );
+    }
+
+    const missingArtifacts = def.manifest.artifacts.produces.filter((p) => !args.ctx.exists(p));
+    if (missingArtifacts.length > 0) {
+      throw new Error(
+        `skill missing required artifacts: ${step.skillId}\n- ${missingArtifacts.join("\n- ")}`
+      );
+    }
+
+    results.push({
+      skillId: step.skillId,
+      outputs,
+      artifacts: def.manifest.artifacts.produces,
+      ops: ops ?? []
+    });
+    args.ctx.log({ event: "skill.finished", skillId: step.skillId });
+  }
+
+  return results;
+}

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -1,0 +1,54 @@
+export type Mode = "advisory" | "supervised" | "autonomous";
+
+export type SkillManifest = {
+  apiVersion: "mar21/skill-v1";
+  id: string;
+  domain: string;
+  description: string;
+  inputs: { schema: Record<string, unknown> };
+  outputs: { schema: Record<string, unknown> };
+  usesConnectors: string[];
+  risk: { level: "none" | "low" | "medium" | "high"; writes: boolean };
+  artifacts: { produces: string[] };
+  idempotency: { strategy: "pure" | "snapshot_based" | "tool_write" };
+};
+
+export type SkillDefinition = {
+  manifestPath: string;
+  dir: string;
+  manifest: SkillManifest;
+};
+
+export type SkillStep = {
+  skillId: string;
+  inputs?: Record<string, unknown>;
+};
+
+export type RunContext = {
+  repoRoot: string;
+  workspaceId: string;
+  workspaceRoot: string;
+  runId: string;
+  runDir: string;
+  inputsDir: string;
+  outputsDir: string;
+  evidenceDir: string;
+  mode: Mode;
+  since: string;
+  dryRun: boolean;
+  context: unknown;
+  request: unknown;
+  writeText: (relativePath: string, content: string) => void;
+  writeJson: (relativePath: string, data: unknown) => void;
+  writeYaml: (relativePath: string, data: unknown) => void;
+  exists: (relativePath: string) => boolean;
+  log: (event: Record<string, unknown>) => void;
+};
+
+export type SkillExecutionResult = {
+  skillId: string;
+  outputs: unknown;
+  artifacts: string[];
+  ops: Array<Record<string, unknown>>;
+};
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@mar21/core':
+        specifier: workspace:*
+        version: link:../core
       ajv:
         specifier: ^8.17.1
         version: 8.18.0
@@ -34,6 +37,16 @@ importers:
         version: 5.9.3
 
   packages/core:
+    dependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.18.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.18.0)
+      yaml:
+        specifier: ^2.7.0
+        version: 2.8.2
     devDependencies:
       '@types/node':
         specifier: ^22.13.10

--- a/skills/ads/meta_creative_refresh_plan/skill.yaml
+++ b/skills/ads/meta_creative_refresh_plan/skill.yaml
@@ -1,0 +1,34 @@
+apiVersion: mar21/skill-v1
+id: ads.meta_creative_refresh_plan
+domain: ads
+description: "Produce a creative refresh plan for Meta Ads (template-first in v0.1)."
+
+inputs:
+  schema:
+    type: object
+    additionalProperties: true
+    properties:
+      focus: { type: string }
+
+outputs:
+  schema:
+    type: object
+    required: [planRef]
+    additionalProperties: true
+    properties:
+      planRef: { type: string }
+
+usesConnectors:
+  - meta_ads.read.insights.by_ad
+
+risk:
+  level: none
+  writes: false
+
+artifacts:
+  produces:
+    - outputs/creative_refresh_plan.md
+
+idempotency:
+  strategy: snapshot_based
+

--- a/skills/content/brief_generate/skill.yaml
+++ b/skills/content/brief_generate/skill.yaml
@@ -1,0 +1,37 @@
+apiVersion: mar21/skill-v1
+id: content.brief_generate
+domain: content
+description: "Generate an execution-ready creative brief (template-first in v0.1)."
+
+inputs:
+  schema:
+    type: object
+    additionalProperties: true
+    properties:
+      assetType:
+        type: string
+        description: "Asset type hint (e.g. landing_page, ad, email, blog)."
+
+outputs:
+  schema:
+    type: object
+    required: [briefRef]
+    additionalProperties: true
+    properties:
+      briefRef: { type: string }
+      assetType: { type: string }
+      primaryKpi: { type: string }
+
+usesConnectors: []
+
+risk:
+  level: none
+  writes: false
+
+artifacts:
+  produces:
+    - outputs/creative_brief.yaml
+
+idempotency:
+  strategy: snapshot_based
+

--- a/skills/content/wordpress_draft_create/skill.yaml
+++ b/skills/content/wordpress_draft_create/skill.yaml
@@ -1,0 +1,37 @@
+apiVersion: mar21/skill-v1
+id: content.wordpress_draft_create
+domain: content
+description: "Create a local draft (v0.1) + propose supervised tasks for WordPress draft creation."
+
+inputs:
+  schema:
+    type: object
+    additionalProperties: true
+    properties:
+      title: { type: string }
+      cta: { type: string }
+
+outputs:
+  schema:
+    type: object
+    required: [draftRef]
+    additionalProperties: true
+    properties:
+      draftRef: { type: string }
+      title: { type: string }
+      cta: { type: string }
+
+usesConnectors:
+  - wordpress.write.post.create_draft
+
+risk:
+  level: low
+  writes: false
+
+artifacts:
+  produces:
+    - outputs/drafts/wordpress_draft_v1.md
+
+idempotency:
+  strategy: snapshot_based
+


### PR DESCRIPTION
Closes #45.

What shipped (v0.1)
- `@mar21/core` skill runtime:
  - Discovers manifests under `skills/**/skill.yaml`.
  - Validates skill inputs/outputs using the manifest JSON Schemas (AJV 2020-12).
  - Enforces required artifacts listed in `artifacts.produces`.
- CLI workflow wiring:
  - `mar21 plan content_brief` runs `content.brief_generate`.
  - `mar21 plan landing_page_iteration` runs a small pipeline:
    - `content.brief_generate`
    - `content.wordpress_draft_create` (local draft + `mar21.todo.create` ops)
    - `ads.meta_creative_refresh_plan` (plan + `mar21.todo.create` op)
  - Writes per-skill outputs to `outputs/skill_outputs/<skill>.json`.

New skills (template-first)
- `skills/content/brief_generate/skill.yaml`
- `skills/content/wordpress_draft_create/skill.yaml`
- `skills/ads/meta_creative_refresh_plan/skill.yaml`

Manual test
- `node packages/cli/dist/index.js plan content_brief --workspace demo --json`
- `node packages/cli/dist/index.js plan landing_page_iteration --workspace demo --json`
- `node packages/cli/dist/index.js apply <runId> --workspace demo --yes --json`
