### PR TITLE
MCP adapter: capability mapping + deep research MCP sources

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -30,10 +30,47 @@ Use these for “bring your own server” debugging:
 - `mar21 mcp tools --workspace <id> --server <serverId>`: list tools (stdio only)
 - `mar21 mcp call --workspace <id> --server <serverId> --tool <toolName> --input <json>`: call tool (stdio only)
 
+## Using MCP inside runs (v0.1: deep research sources)
+`deep_research_sparring` can ingest MCP tool outputs as private evidence when you provide selectors in `--request`:
+
+```yaml
+params:
+  research:
+    sources:
+      mcpLimits:
+        maxCalls: 10
+      mcp:
+        - title: "Slack: competitor mentions"
+          serverId: slack
+          capabilityId: slack.read.messages.search
+          input:
+            query: "competitor name"
+```
+
+Outputs:
+- `outputs/evidence/mcp_sources.json`
+- `outputs/evidence/mcp_*.md` excerpts (redacted)
+- `outputs/research_pack.md` with `[S#]` citations like `mcp:server:slack:tool:<toolName>`
+
+## Capability mapping (recommended)
+To let `mar21` workflows call MCP tools **without hard-coding server-specific tool names**, you can map stable capability ids to tool names in `mcp-servers.yaml`:
+
+```yaml
+servers:
+  - id: slack
+    transport: stdio
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-slack"]
+    capabilities:
+      - capabilityId: slack.write.message.post
+        toolName: post_message
+```
+
+If you later switch MCP servers, you can keep workflows stable by updating only these mappings.
+
 ## Safety boundaries (non-negotiable)
 Even when using MCP:
 - evidence pulls are **metadata-first**
 - raw bytes are **cache-only** by default for private sources
 - prompts/outputs must cite sources (`drive:fileId:<id>`, URLs, etc.)
 - sensitive reads/writes require interactive approvals (supervised-by-default)
-

--- a/examples/mcp-servers.yaml
+++ b/examples/mcp-servers.yaml
@@ -10,6 +10,17 @@ servers:
     args:
       - -y
       - "@modelcontextprotocol/server-gdrive"
+    capabilities:
+      # If the MCP server uses different tool names, map stable mar21 capability ids -> tool names here.
+      # Example names are placeholders; use `mar21 mcp tools` to see the real names exposed by your server.
+      - capabilityId: gdrive.read.files.search
+        toolName: gdrive.read.files.search
+      - capabilityId: gdrive.read.files.get_metadata
+        toolName: gdrive.read.files.get_metadata
+      - capabilityId: gdrive.read.files.export
+        toolName: gdrive.read.files.export
+      - capabilityId: gdrive.read.files.download
+        toolName: gdrive.read.files.download
     env:
       # Map workspace secrets (loaded from `workspaces/<ws>/secrets/.env`) into whatever the server expects.
       # You may need to adjust these keys to match the server's README.
@@ -26,7 +37,11 @@ servers:
     args:
       - -y
       - "@modelcontextprotocol/server-slack"
+    capabilities:
+      - capabilityId: slack.read.messages.search
+        toolName: slack.read.messages.search
+      - capabilityId: slack.write.message.post
+        toolName: slack.write.message.post
     env:
       # SLACK_BOT_TOKEN: "${MAR21_SLACK_BOT_TOKEN}"
       MAR21_SLACK_BOT_TOKEN: "${MAR21_SLACK_BOT_TOKEN}"
-

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -223,6 +223,12 @@ function mcpServersTemplate(connectors: ConnectorId[]): string {
       transport: "stdio",
       command: "npx",
       args: ["-y", "@modelcontextprotocol/server-gdrive"],
+      capabilities: [
+        { capabilityId: "gdrive.read.files.search", toolName: "gdrive.read.files.search" },
+        { capabilityId: "gdrive.read.files.get_metadata", toolName: "gdrive.read.files.get_metadata" },
+        { capabilityId: "gdrive.read.files.export", toolName: "gdrive.read.files.export" },
+        { capabilityId: "gdrive.read.files.download", toolName: "gdrive.read.files.download" }
+      ],
       env: {
         // NOTE: server env keys vary by implementation; adjust to match the chosen server README.
         MAR21_GDRIVE_CLIENT_ID: "${MAR21_GDRIVE_CLIENT_ID}",
@@ -239,6 +245,10 @@ function mcpServersTemplate(connectors: ConnectorId[]): string {
       transport: "stdio",
       command: "npx",
       args: ["-y", "@modelcontextprotocol/server-slack"],
+      capabilities: [
+        { capabilityId: "slack.read.messages.search", toolName: "slack.read.messages.search" },
+        { capabilityId: "slack.write.message.post", toolName: "slack.write.message.post" }
+      ],
       env: {
         MAR21_SLACK_BOT_TOKEN: "${MAR21_SLACK_BOT_TOKEN}"
       },

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import YAML from "yaml";
-import { callMcpTool, listMcpTools, loadMcpServersFile, loadWorkspaceSecretsIntoEnv } from "@mar21/mcp";
+import { callMcpToolIsolated, listMcpToolsIsolated, loadMcpServersFile, loadWorkspaceSecretsIntoEnv } from "@mar21/mcp";
 import { requireWorkspaceRoot, resolveWorkspaceId } from "./workspace.js";
 
 type Ajv2020Class = typeof import("ajv/dist/2020.js").default;
@@ -51,6 +51,21 @@ function readYamlFile(filePath: string): unknown {
     err.exitCode = 11;
     throw err;
   }
+}
+
+function asMcpCliError(action: string, serverId: string, err: unknown): Error & { exitCode?: number } {
+  const msg = err instanceof Error ? err.message : String(err);
+  const hints: string[] = [];
+  if (/credentials not found/i.test(msg) || /\bauth\b/i.test(msg)) {
+    hints.push("server requires auth/bootstrap; run the server's documented auth flow first");
+  }
+  if (/connection closed/i.test(msg)) {
+    hints.push("server process exited early; check env vars and run the command manually to see stderr");
+  }
+  const hint = hints.length > 0 ? `\nHint: ${hints.join("; ")}.` : "";
+  const e = new Error(`MCP ${action} failed for server '${serverId}': ${msg}${hint}`) as Error & { exitCode?: number };
+  e.exitCode = 20;
+  return e;
 }
 
 export async function mcpDoctor(opts: { workspace?: string; json?: boolean }): Promise<void> {
@@ -136,7 +151,12 @@ export async function mcpTools(opts: { workspace?: string; serverId: string; jso
     throw err;
   }
 
-  const tools = await listMcpTools(server as any);
+  let tools: Array<{ name: string; description?: string }> = [];
+  try {
+    tools = await listMcpToolsIsolated(server as any);
+  } catch (e) {
+    throw asMcpCliError("tools", opts.serverId, e);
+  }
   if (opts.json) {
     process.stdout.write(`${JSON.stringify({ tools })}\n`);
     return;
@@ -185,7 +205,12 @@ export async function mcpCall(opts: {
     throw err;
   }
 
-  const out = await callMcpTool(server as any, opts.tool, input);
+  let out: unknown;
+  try {
+    out = await callMcpToolIsolated(server as any, opts.tool, input);
+  } catch (e) {
+    throw asMcpCliError(`call (${opts.tool})`, opts.serverId, e);
+  }
   const raw = JSON.stringify(out, null, opts.json ? 0 : 2);
   process.stdout.write(`${raw}\n`);
 }

--- a/packages/cli/src/run-engine.ts
+++ b/packages/cli/src/run-engine.ts
@@ -1,9 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import process from "node:process";
 import readline from "node:readline/promises";
 import YAML from "yaml";
 import { executeSkillPipeline, type SkillExecutionResult, type SkillStep } from "@mar21/core";
+import {
+  callMcpToolIsolated,
+  loadMcpServersFile,
+  loadWorkspaceSecretsIntoEnv,
+  resolveToolForCapability
+} from "@mar21/mcp";
 import {
   defaultModeFromContext,
   ensureDir,
@@ -108,6 +115,68 @@ function reportTemplate(workflowId: string): string {
 ## Next checkpoint
 - …
 `;
+}
+
+function sha256Hex(text: string): string {
+  return createHash("sha256").update(text, "utf-8").digest("hex");
+}
+
+function redactBasic(text: string): { redacted: string; stats: { emails: number; phones: number; longIds: number } } {
+  let out = text;
+  let emails = 0;
+  let phones = 0;
+  let longIds = 0;
+
+  out = out.replace(/[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}/gi, () => {
+    emails += 1;
+    return "[REDACTED_EMAIL]";
+  });
+
+  out = out.replace(/(\\+?\\d[\\d\\s().-]{7,}\\d)/g, () => {
+    phones += 1;
+    return "[REDACTED_PHONE]";
+  });
+
+  out = out.replace(/(?=[A-Za-z0-9_-]{24,})(?=.*\\d)[A-Za-z0-9_-]+/g, (m) => {
+    longIds += 1;
+    return `[REDACTED_ID:${Math.min(8, m.length)}]`;
+  });
+
+  return { redacted: out, stats: { emails, phones, longIds } };
+}
+
+function safeFileSlug(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 64);
+}
+
+function nextEvidenceNumber(existing: unknown): number {
+  const arr = Array.isArray(existing) ? existing : [];
+  let max = 0;
+  for (const e of arr as any[]) {
+    const id = typeof e?.id === "string" ? e.id : "";
+    const m = /^E(\\d+)$/.exec(id);
+    if (!m) continue;
+    const n = Number(m[1]);
+    if (Number.isFinite(n)) max = Math.max(max, n);
+  }
+  return max + 1;
+}
+
+function nextSourceNumber(existingSources: Array<{ sourceId?: string }> | null): number {
+  let max = 1; // reserve S1 for public placeholder
+  for (const s of existingSources ?? []) {
+    const sid = typeof s?.sourceId === "string" ? s.sourceId : "";
+    const m = /^S(\\d+)$/.exec(sid);
+    if (!m) continue;
+    const n = Number(m[1]);
+    if (Number.isFinite(n)) max = Math.max(max, n);
+  }
+  return max + 1;
 }
 
 function deepResearchPackTemplate(args: {
@@ -322,6 +391,9 @@ function runPlanSyncDeprecated(workflowIdRaw: string, opts: PlanCommandOptions):
     throw err;
   }
 
+  // Load workspace secrets (if present) for downstream connectors/MCP servers.
+  loadWorkspaceSecretsIntoEnv(wsRoot);
+
   const contextPath = path.join(wsRoot, "marketing-context.yaml");
   if (!fs.existsSync(contextPath)) {
     const err = new Error(`missing marketing context: ${contextPath}`);
@@ -398,7 +470,7 @@ function runPlanSyncDeprecated(workflowIdRaw: string, opts: PlanCommandOptions):
     exists: (relativePath: string) => fs.existsSync(safeJoin(runDir, relativePath)),
     log: (event: Record<string, unknown>) => fs.appendFileSync(logsPath, logsLine(event), "utf-8"),
     confirmSensitiveRead: async (args: {
-      kind: "gdrive_download" | "gdrive_export";
+      kind: "gdrive_download" | "gdrive_export" | "mcp_call";
       count: number;
       approxMB: number;
       reason: string;
@@ -428,12 +500,14 @@ function runPlanSyncDeprecated(workflowIdRaw: string, opts: PlanCommandOptions):
         return false;
       }
 
-      const ok = await promptYesNo(
-        `This run will ${args.kind === "gdrive_export" ? "export" : "download"} ${args.count} Drive file(s) (~${args.approxMB.toFixed(
-          1
-        )} MB). Continue? (y/n) `,
-        promptTo
-      );
+      const verb =
+        args.kind === "gdrive_export"
+          ? `export ${args.count} Drive file(s)`
+          : args.kind === "gdrive_download"
+            ? `download ${args.count} Drive file(s)`
+            : `call ${args.count} MCP tool(s)`;
+      const sizeNote = args.approxMB > 0 ? ` (~${args.approxMB.toFixed(1)} MB)` : "";
+      const ok = await promptYesNo(`This run will ${verb}${sizeNote}. Continue? (y/n) `, promptTo);
       fs.appendFileSync(
         logsPath,
         logsLine({ event: "sensitive_read.decision", kind: args.kind, decision: ok ? "approved" : "rejected" }),
@@ -672,7 +746,7 @@ export async function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): 
     exists: (relativePath: string) => fs.existsSync(safeJoin(runDir, relativePath)),
     log: (event: Record<string, unknown>) => fs.appendFileSync(logsPath, logsLine(event), "utf-8"),
     confirmSensitiveRead: async (args: {
-      kind: "gdrive_download" | "gdrive_export";
+      kind: "gdrive_download" | "gdrive_export" | "mcp_call";
       count: number;
       approxMB: number;
       reason: string;
@@ -702,12 +776,14 @@ export async function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): 
         return false;
       }
 
-      const ok = await promptYesNo(
-        `This run will ${args.kind === "gdrive_export" ? "export" : "download"} ${args.count} Drive file(s) (~${args.approxMB.toFixed(
-          1
-        )} MB). Continue? (y/n) `,
-        promptTo
-      );
+      const verb =
+        args.kind === "gdrive_export"
+          ? `export ${args.count} Drive file(s)`
+          : args.kind === "gdrive_download"
+            ? `download ${args.count} Drive file(s)`
+            : `call ${args.count} MCP tool(s)`;
+      const sizeNote = args.approxMB > 0 ? ` (~${args.approxMB.toFixed(1)} MB)` : "";
+      const ok = await promptYesNo(`This run will ${verb}${sizeNote}. Continue? (y/n) `, promptTo);
       fs.appendFileSync(
         logsPath,
         logsLine({ event: "sensitive_read.decision", kind: args.kind, decision: ok ? "approved" : "rejected" }),
@@ -813,29 +889,229 @@ export async function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): 
       };
     })();
 
+    const mcpCalls = (() => {
+      const p = (request.params ?? {}) as any;
+      const arr = p?.research?.sources?.mcp;
+      return Array.isArray(arr) ? (arr as any[]) : [];
+    })();
+
+    const mcpSourcesPath = path.join(evidenceDir, "mcp_sources.json");
+    if (mcpCalls.length > 0) {
+      const cfg = loadMcpServersFile(wsRoot);
+      if (!cfg) {
+        const err = new Error(`MCP sources requested but missing config: ${path.join(wsRoot, "_cfg", "mcp-servers.yaml")}`) as Error & {
+          exitCode?: number;
+        };
+        err.exitCode = 10;
+        throw err;
+      }
+
+      const maxCalls = (() => {
+        const p = (request.params ?? {}) as any;
+        const v = p?.research?.sources?.mcpLimits?.maxCalls;
+        return typeof v === "number" && v >= 0 ? v : 10;
+      })();
+
+      const exceeds = mcpCalls.length > maxCalls;
+      let approvedToExceed: boolean | null = null;
+      if (exceeds) {
+        const ok = await (ctx as any).confirmSensitiveRead({
+          kind: "mcp_call",
+          count: mcpCalls.length,
+          approxMB: 0,
+          reason: `planned MCP calls (${mcpCalls.length}) exceed maxCalls (${maxCalls})`
+        });
+        approvedToExceed = ok;
+        if (!ok) {
+          writeJson(mcpSourcesPath, {
+            skipped: true,
+            reason: "operator_rejected",
+            plannedCount: mcpCalls.length,
+            maxCalls,
+            sources: []
+          });
+        }
+      }
+
+      if (!fs.existsSync(mcpSourcesPath)) {
+        const evidenceJsonPath = path.join(evidenceDir, "evidence.json");
+        const existingEvidence = fs.existsSync(evidenceJsonPath)
+          ? (JSON.parse(fs.readFileSync(evidenceJsonPath, "utf-8")) as unknown)
+          : [];
+        const evidenceArr = Array.isArray(existingEvidence) ? (existingEvidence as any[]) : [];
+        let nextE = nextEvidenceNumber(evidenceArr);
+        let nextS = nextSourceNumber(sourcesData?.sources ?? null);
+
+        const sources: Array<Record<string, unknown>> = [];
+        const accessedDate = accessedAt.slice(0, 10);
+        const callsToApply = exceeds ? (approvedToExceed ? mcpCalls : mcpCalls.slice(0, maxCalls)) : mcpCalls;
+
+        for (const c of callsToApply) {
+          const serverId = c?.serverId ? String(c.serverId) : null;
+          const capabilityId = c?.capabilityId ? String(c.capabilityId) : null;
+          const tool = c?.tool ? String(c.tool) : null;
+          const input = c?.input && typeof c.input === "object" ? c.input : {};
+
+          const resolved = (() => {
+            if (tool) {
+              if (!serverId) return null;
+              const server = cfg.servers.find((s) => s.id === serverId);
+              if (!server) return null;
+              return { server, toolName: tool };
+            }
+            if (capabilityId) {
+              const hit = resolveToolForCapability({
+                servers: cfg.servers as any,
+                capabilityId,
+                preferredServerId: serverId ?? undefined
+              });
+              return hit ? { server: hit.server as any, toolName: hit.toolName } : null;
+            }
+            return null;
+          })();
+
+          if (!resolved) {
+            ctx.log({
+              event: "mcp.ingest.skipped",
+              reason: "unresolved_tool",
+              serverId,
+              capabilityId,
+              tool
+            });
+            continue;
+          }
+
+          const sourceRef = `mcp:server:${resolved.server.id}:tool:${resolved.toolName}`;
+          try {
+            const raw = await callMcpToolIsolated(resolved.server as any, resolved.toolName, input, { timeoutMs: 30_000 });
+            const rawJson = JSON.stringify(raw, null, 2);
+            const { redacted, stats } = redactBasic(rawJson);
+            const excerpt = [
+              "# MCP excerpt",
+              "",
+              `- source: ${sourceRef}`,
+              `- server: ${resolved.server.id}`,
+              `- tool: ${resolved.toolName}`,
+              `- accessed: ${accessedDate}`,
+              "",
+              "## Output (redacted JSON)",
+              "",
+              "```json",
+              redacted.slice(0, 8000),
+              "```",
+              "",
+              "## Redaction",
+              "",
+              `- emails: ${stats.emails}`,
+              `- phones: ${stats.phones}`,
+              `- longIds: ${stats.longIds}`,
+              ""
+            ].join("\n");
+
+            const outPath = `outputs/evidence/mcp_${safeFileSlug(resolved.server.id)}_${safeFileSlug(resolved.toolName)}_${nextE}.md`;
+            ctx.writeText(outPath, excerpt);
+
+            const sha = sha256Hex(excerpt);
+            evidenceArr.push({
+              id: `E${nextE}`,
+              sourceRef,
+              derivedFrom: "private_tool",
+              path: outPath,
+              contentType: "text/markdown",
+              redacted: true,
+              sha256: sha,
+              notes: "MCP tool output excerpt (redacted)"
+            });
+
+            sources.push({
+              sourceId: `S${nextS}`,
+              type: "private_tool",
+              sourceRef,
+              name: c?.title ? String(c.title) : `${resolved.server.id}:${resolved.toolName}`,
+              accessedDate,
+              excerptRef: outPath,
+              sha256: sha
+            });
+
+            nextE += 1;
+            nextS += 1;
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            ctx.log({ event: "mcp.ingest.failed", serverId: resolved.server.id, tool: resolved.toolName, error: msg });
+          }
+        }
+
+        writeJson(evidenceJsonPath, evidenceArr);
+        writeJson(mcpSourcesPath, {
+          skipped: false,
+          plannedCount: mcpCalls.length,
+          appliedCount: sources.length,
+          maxCalls,
+          capsExceeded: exceeds,
+          operatorApprovedToExceed: approvedToExceed,
+          sources
+        });
+      }
+    } else {
+      if (!fs.existsSync(mcpSourcesPath)) {
+        writeJson(mcpSourcesPath, { skipped: false, plannedCount: 0, appliedCount: 0, maxCalls: 10, sources: [] });
+      }
+    }
+
     const accessed = accessedAt.slice(0, 10);
+    const mcpSourcesData = (() => {
+      if (!fs.existsSync(mcpSourcesPath)) return null;
+      const parsed = JSON.parse(fs.readFileSync(mcpSourcesPath, "utf-8")) as any;
+      const arr = Array.isArray(parsed) ? parsed : Array.isArray(parsed?.sources) ? parsed.sources : null;
+      if (!Array.isArray(arr)) return null;
+      return {
+        meta: {
+          plannedCount: typeof parsed?.plannedCount === "number" ? parsed.plannedCount : null,
+          appliedCount: typeof parsed?.appliedCount === "number" ? parsed.appliedCount : null,
+          maxCalls: typeof parsed?.maxCalls === "number" ? parsed.maxCalls : null,
+          capsExceeded: typeof parsed?.capsExceeded === "boolean" ? parsed.capsExceeded : null,
+          operatorApprovedToExceed: typeof parsed?.operatorApprovedToExceed === "boolean" ? parsed.operatorApprovedToExceed : null
+        },
+        sources: arr as Array<{
+          sourceId?: string;
+          sourceRef?: string;
+          name?: string | null;
+          accessedDate?: string;
+          excerptRef?: string;
+        }>
+      };
+    })();
+
     const lines: string[] = [];
     lines.push("# Research Pack — deep_research_sparring");
     lines.push("");
     lines.push("This is a **v0.1** research pack scaffold:");
     lines.push("- claims should be tied to sources via `[S#]`");
-    lines.push("- sources can be **public** and **private** (e.g. Drive refs)");
+    lines.push("- sources can be **public** and **private** (e.g. Drive refs, MCP tools)");
     lines.push("");
     lines.push("## Findings (stub)");
     lines.push(
       "- Evidence-based loops beat ad-hoc tactics: map recommendations to KPI nodes and measurable next actions. [S1]"
     );
-    if (sourcesData && sourcesData.sources.length > 0) {
-      const firstSid = sourcesData.sources[0]?.sourceId ?? "S2";
-      const extra =
-        sourcesData.meta.skippedItemsCount && sourcesData.meta.skippedItemsCount > 0
+    const driveCount = sourcesData?.sources.length ?? 0;
+    const mcpCount = mcpSourcesData?.sources.length ?? 0;
+    const privateTotal = driveCount + mcpCount;
+    if (privateTotal > 0) {
+      const firstSid = (sourcesData?.sources[0]?.sourceId ?? mcpSourcesData?.sources[0]?.sourceId) ?? "S2";
+      const driveExtra =
+        sourcesData?.meta.skippedItemsCount && sourcesData.meta.skippedItemsCount > 0
           ? ` (${sourcesData.meta.skippedItemsCount} skipped due to caps)`
           : "";
-      lines.push(
-        `- Private sources ingested from Drive (${sourcesData.sources.length})${extra}. See excerpts. [${firstSid}]`
-      );
+      const mcpExtra =
+        mcpSourcesData?.meta.capsExceeded && mcpSourcesData.meta.operatorApprovedToExceed === false
+          ? " (some skipped due to caps)"
+          : "";
+      const parts: string[] = [];
+      if (driveCount > 0) parts.push(`Drive (${driveCount})${driveExtra}`);
+      if (mcpCount > 0) parts.push(`MCP (${mcpCount})${mcpExtra}`);
+      lines.push(`- Private sources ingested: ${parts.join(", ")}. See excerpts. [${firstSid}]`);
     } else {
-      lines.push("- No private sources ingested in this run (provide request params to enable Drive).");
+      lines.push("- No private sources ingested in this run (provide request params to enable Drive/MCP).");
     }
     lines.push("");
     lines.push("## Sources");
@@ -851,13 +1127,31 @@ export async function runPlan(workflowIdRaw: string, opts: PlanCommandOptions): 
         lines.push(`- [${sid}] (private_doc) ${name} — ${ref} — accessed ${ad}`);
       }
     }
-    lines.push("");
-    if (sourcesData && sourcesData.sources.length > 0) {
-      lines.push("## Private excerpts");
-      for (const s of sourcesData.sources) {
-        if (!s.excerptRef) continue;
+    if (mcpSourcesData && mcpSourcesData.sources.length > 0) {
+      for (const s of mcpSourcesData.sources) {
         const sid = s.sourceId ?? "S?";
-        lines.push(`- [${sid}] ${s.excerptRef}`);
+        const ref = s.sourceRef ?? "mcp:server:unknown:tool:unknown";
+        const name = s.name ? String(s.name) : "(unnamed)";
+        const ad = s.accessedDate ?? accessed;
+        lines.push(`- [${sid}] (private_tool) ${name} — ${ref} — accessed ${ad}`);
+      }
+    }
+    lines.push("");
+    if ((sourcesData && sourcesData.sources.length > 0) || (mcpSourcesData && mcpSourcesData.sources.length > 0)) {
+      lines.push("## Private excerpts");
+      if (sourcesData && sourcesData.sources.length > 0) {
+        for (const s of sourcesData.sources) {
+          if (!s.excerptRef) continue;
+          const sid = s.sourceId ?? "S?";
+          lines.push(`- [${sid}] ${s.excerptRef}`);
+        }
+      }
+      if (mcpSourcesData && mcpSourcesData.sources.length > 0) {
+        for (const s of mcpSourcesData.sources) {
+          if (!s.excerptRef) continue;
+          const sid = s.sourceId ?? "S?";
+          lines.push(`- [${sid}] ${s.excerptRef}`);
+        }
       }
       lines.push("");
     }

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -44,7 +44,7 @@ export type RunContext = {
   exists: (relativePath: string) => boolean;
   log: (event: Record<string, unknown>) => void;
   confirmSensitiveRead: (args: {
-    kind: "gdrive_download" | "gdrive_export";
+    kind: "gdrive_download" | "gdrive_export" | "mcp_call";
     count: number;
     approxMB: number;
     reason: string;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { spawn } from "node:child_process";
 import YAML from "yaml";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -12,6 +13,7 @@ export type McpServerConfig = {
   args?: string[];
   cwd?: string;
   env?: Record<string, string>;
+  capabilities?: Array<{ capabilityId: string; toolName: string }>;
   url?: string;
   notes?: string;
 };
@@ -59,6 +61,37 @@ export function loadMcpServersFile(workspaceRoot: string): McpServersFile | null
   return { apiVersion: "mar21/mcp-servers-v1", servers: doc.servers as McpServerConfig[] };
 }
 
+export function resolveToolForCapability(args: {
+  servers: McpServerConfig[];
+  capabilityId: string;
+  preferredServerId?: string;
+}): { server: McpServerConfig; toolName: string } | null {
+  const cap = args.capabilityId.trim();
+  if (!cap) return null;
+
+  const ordered = (() => {
+    if (!args.preferredServerId) return args.servers;
+    const preferred = args.servers.filter((s) => s.id === args.preferredServerId);
+    const rest = args.servers.filter((s) => s.id !== args.preferredServerId);
+    return [...preferred, ...rest];
+  })();
+
+  for (const s of ordered) {
+    const map = Array.isArray(s.capabilities) ? s.capabilities : [];
+    const hit = map.find((m) => m && typeof m === "object" && m.capabilityId === cap && typeof m.toolName === "string");
+    if (hit) return { server: s, toolName: hit.toolName };
+  }
+
+  // Fallback convention: if a server exposes tool names equal to mar21 capability ids,
+  // operators can omit explicit mappings and call by capabilityId directly.
+  if (args.preferredServerId) {
+    const direct = ordered.find((s) => s.id === args.preferredServerId);
+    if (direct) return { server: direct, toolName: cap };
+  }
+  if (ordered.length === 1) return { server: ordered[0]!, toolName: cap };
+  return null;
+}
+
 function expandEnvValue(template: string): string {
   return template.replace(/\$\{([A-Z0-9_]+)\}/g, (_m, name) => process.env[String(name)] ?? "");
 }
@@ -77,9 +110,38 @@ function processEnvStrings(): Record<string, string> {
   return out;
 }
 
+async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  let t: NodeJS.Timeout | null = null;
+  try {
+    const timeout = new Promise<never>((_resolve, reject) => {
+      t = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      (t as any)?.unref?.();
+    });
+    return (await Promise.race([p, timeout])) as T;
+  } finally {
+    if (t) clearTimeout(t);
+  }
+}
+
+async function safeClose(client: Client, transport: StdioClientTransport, label: string): Promise<void> {
+  try {
+    await withTimeout(client.close(), 2000, `${label} close(client)`);
+  } catch {
+    // ignore
+  }
+  try {
+    // Transport close already includes its own bounded waits + SIGTERM/SIGKILL escalation.
+    await withTimeout(transport.close(), 8000, `${label} close(transport)`);
+  } catch {
+    // ignore
+  }
+}
+
 export async function withMcpClient<T>(
   server: McpServerConfig,
-  fn: (client: Client) => Promise<T>
+  fn: (client: Client) => Promise<T>,
+  opts?: { connectTimeoutMs?: number; callTimeoutMs?: number }
 ): Promise<T> {
   if (server.transport !== "stdio") {
     const err = new Error(`unsupported MCP transport in v0.1: ${server.transport}`) as Error & { exitCode?: number };
@@ -106,11 +168,23 @@ export async function withMcpClient<T>(
     { capabilities: {} }
   );
 
-  await client.connect(transport);
+  const connectTimeoutMs = opts?.connectTimeoutMs ?? 15_000;
+  const callTimeoutMs = opts?.callTimeoutMs ?? 30_000;
+
   try {
-    return await fn(client);
+    await withTimeout(client.connect(transport), connectTimeoutMs, `mcp connect (${server.id})`);
+  } catch (e) {
+    try {
+      await withTimeout(transport.close(), 8000, `mcp connect (${server.id}) close(transport)`);
+    } catch {
+      // ignore
+    }
+    throw e;
+  }
+  try {
+    return await withTimeout(fn(client), callTimeoutMs, `mcp call (${server.id})`);
   } finally {
-    await client.close();
+    await safeClose(client, transport, `mcp (${server.id})`);
   }
 }
 
@@ -128,4 +202,132 @@ export async function callMcpTool(server: McpServerConfig, tool: string, input: 
     const res = await client.callTool({ name: tool, arguments: input as any });
     return res as unknown;
   });
+}
+
+type IsolatedResult =
+  | { ok: true; result: unknown }
+  | { ok: false; error: { message: string } };
+
+function spawnNodeIsolated(payload: unknown, timeoutMs: number): Promise<IsolatedResult> {
+  const script = `
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const b64 = process.env.MAR21_MCP_PAYLOAD || "";
+const raw = Buffer.from(b64, "base64").toString("utf-8");
+const payload = JSON.parse(raw);
+
+const client = new Client({ name: "mar21", version: "0.1.0" }, { capabilities: {} });
+const transport = new StdioClientTransport({
+  command: payload.command,
+  args: payload.args || [],
+  env: payload.env || {},
+  cwd: payload.cwd || undefined
+});
+
+async function main() {
+  try {
+    await client.connect(transport);
+    const mode = payload.mode;
+    if (mode === "tools") {
+      const res = await client.listTools();
+      process.stdout.write(JSON.stringify({ ok: true, result: res }));
+      return;
+    }
+    if (mode === "call") {
+      const res = await client.callTool({ name: payload.tool, arguments: payload.input || {} });
+      process.stdout.write(JSON.stringify({ ok: true, result: res }));
+      return;
+    }
+    process.stdout.write(JSON.stringify({ ok: false, error: { message: "unsupported mode" } }));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stdout.write(JSON.stringify({ ok: false, error: { message: msg } }));
+  } finally {
+    try { await client.close(); } catch {}
+    try { await transport.close(); } catch {}
+    process.exit(0);
+  }
+}
+
+await main();
+`;
+
+  const b64 = Buffer.from(JSON.stringify(payload), "utf-8").toString("base64");
+  const child = spawn(process.execPath, ["--input-type=module", "-e", script], {
+    env: { ...processEnvStrings(), MAR21_MCP_PAYLOAD: b64 },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+
+  return new Promise<IsolatedResult>((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const t = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // ignore
+      }
+      resolve({ ok: false, error: { message: `isolated MCP timed out after ${timeoutMs}ms` } });
+    }, timeoutMs);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    (t as any)?.unref?.();
+
+    child.stdout?.on("data", (d) => (stdout += d.toString("utf-8")));
+    child.stderr?.on("data", (d) => (stderr += d.toString("utf-8")));
+    child.on("error", (e) => {
+      clearTimeout(t);
+      reject(e);
+    });
+    child.on("close", () => {
+      clearTimeout(t);
+      try {
+        const parsed = JSON.parse(stdout.trim() || "{}") as IsolatedResult;
+        if (parsed && typeof parsed === "object" && "ok" in parsed) {
+          resolve(parsed);
+          return;
+        }
+        resolve({ ok: false, error: { message: stderr.trim() || "invalid isolated MCP output" } });
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        resolve({ ok: false, error: { message: `${msg}${stderr.trim() ? `: ${stderr.trim()}` : ""}` } });
+      }
+    });
+  });
+}
+
+function serverSpawnParams(server: McpServerConfig): { command: string; args: string[]; cwd?: string; env: Record<string, string> } {
+  if (server.transport !== "stdio" || !server.command) {
+    throw new Error(`unsupported MCP transport/server for isolated mode: ${server.id}`);
+  }
+  return {
+    command: server.command,
+    args: server.args ?? [],
+    cwd: server.cwd,
+    env: { ...resolvedServerEnv(server.env) }
+  };
+}
+
+export async function listMcpToolsIsolated(
+  server: McpServerConfig,
+  opts?: { timeoutMs?: number }
+): Promise<{ name: string; description?: string }[]> {
+  const params = serverSpawnParams(server);
+  const res = await spawnNodeIsolated({ ...params, mode: "tools" }, opts?.timeoutMs ?? 20_000);
+  if (!res.ok) throw new Error(res.error.message);
+  const tools = (res.result as any)?.tools;
+  if (!Array.isArray(tools)) return [];
+  return tools.map((t: any) => ({ name: String(t.name), description: t.description ? String(t.description) : undefined }));
+}
+
+export async function callMcpToolIsolated(
+  server: McpServerConfig,
+  tool: string,
+  input: unknown,
+  opts?: { timeoutMs?: number }
+): Promise<unknown> {
+  const params = serverSpawnParams(server);
+  const res = await spawnNodeIsolated({ ...params, mode: "call", tool, input }, opts?.timeoutMs ?? 30_000);
+  if (!res.ok) throw new Error(res.error.message);
+  return res.result;
 }

--- a/schemas/mcp-servers.schema.json
+++ b/schemas/mcp-servers.schema.json
@@ -47,6 +47,28 @@
             "additionalProperties": { "type": "string" },
             "default": {}
           },
+          "capabilities": {
+            "type": "array",
+            "default": [],
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["capabilityId", "toolName"],
+              "properties": {
+                "capabilityId": {
+                  "type": "string",
+                  "minLength": 3,
+                  "maxLength": 128,
+                  "pattern": "^[a-z0-9]+\\.[a-z0-9]+\\.[a-z0-9_.-]+\\.[a-z0-9_.-]+$"
+                },
+                "toolName": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                }
+              }
+            }
+          },
           "url": {
             "type": "string",
             "minLength": 1,
@@ -71,4 +93,3 @@
     }
   }
 }
-

--- a/schemas/request.schema.json
+++ b/schemas/request.schema.json
@@ -41,6 +41,27 @@
                       }
                     }
                   }
+                },
+                "mcpLimits": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "maxCalls": { "type": "number", "minimum": 0 }
+                  }
+                },
+                "mcp": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                      "title": { "type": "string" },
+                      "serverId": { "type": "string" },
+                      "capabilityId": { "type": "string" },
+                      "tool": { "type": "string" },
+                      "input": { "type": "object", "additionalProperties": true }
+                    }
+                  }
                 }
               }
             }
@@ -50,4 +71,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Closes #53

## What
- Adds `capabilities:` mappings to `workspaces/<ws>/_cfg/mcp-servers.yaml` (capabilityId -> toolName).
- Extends request schema for MCP research sources: `params.research.sources.mcp[]` (+ `mcpLimits.maxCalls`).
- `deep_research_sparring` can ingest MCP tool outputs into `outputs/evidence/` and cite them in `outputs/research_pack.md` as `mcp:server:<id>:tool:<name>`.
- Hardens MCP CLI commands (`mar21 mcp tools/call`) with friendly errors + exit code `20` and no hangs by using isolated execution.

## Manual tests
- `pnpm build`
- `node packages/cli/dist/index.js validate --examples`
- `node packages/cli/dist/index.js plan deep_research_sparring --workspace mcptest --request /tmp/request-mcp.yaml --json` (creates `outputs/evidence/mcp_sources.json`)
- `node packages/cli/dist/index.js mcp tools --workspace mcptest --server slack` (fails cleanly with exit 20 if not configured)

## Notes
- MCP calls inside runs are executed in an isolated subprocess to avoid SDK/server handle leaks from hanging the main CLI.