### PR TITLE
CLI: mcp scaffold-mapping

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,6 +20,7 @@ mar21 apply <runId> --workspace <id> [--yes] [--fail-on-reject] [--json]
 mar21 mcp doctor --workspace <id> [--json]
 mar21 mcp tools --workspace <id> --server <serverId> [--json]
 mar21 mcp call --workspace <id> --server <serverId> --tool <toolName> --input <json> [--json]
+mar21 mcp scaffold-mapping --workspace <id> --server <serverId> [--apply] [--force] [--json]
 ```
 
 ### Optional task convenience commands (v1)

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -29,6 +29,7 @@ Use these for “bring your own server” debugging:
 - `mar21 mcp doctor --workspace <id>`: schema validation + basic sanity checks
 - `mar21 mcp tools --workspace <id> --server <serverId>`: list tools (stdio only)
 - `mar21 mcp call --workspace <id> --server <serverId> --tool <toolName> --input <json>`: call tool (stdio only)
+- `mar21 mcp scaffold-mapping --workspace <id> --server <serverId>`: generate a starter `capabilities:` mapping
 
 ## Using MCP inside runs (v0.1: deep research sources)
 `deep_research_sparring` can ingest MCP tool outputs as private evidence when you provide selectors in `--request`:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import process from "node:process";
 import { applyRunChangeset } from "./apply-engine.js";
 import { autopilotStart } from "./autopilot.js";
 import { initWorkspace } from "./init.js";
-import { mcpCall, mcpDoctor, mcpTools } from "./mcp.js";
+import { mcpCall, mcpDoctor, mcpScaffoldMapping, mcpTools } from "./mcp.js";
 import { runCadence } from "./run-cadence.js";
 import { runAnalyze, runPlan, runReport } from "./run-engine.js";
 import { validateExamples } from "./validate.js";
@@ -118,6 +118,24 @@ program
           });
         }
       )
+  )
+  .addCommand(
+    new Command("scaffold-mapping")
+      .description("Scaffold capabilityId mappings from discovered MCP tool names")
+      .requiredOption("--server <id>", "Server id from _cfg/mcp-servers.yaml")
+      .option("--workspace <id>", "Workspace id")
+      .option("--apply", "Write mappings into _cfg/mcp-servers.yaml (rewrites YAML)", false)
+      .option("--force", "Overwrite existing capabilities when used with --apply", false)
+      .option("--json", "Print machine-readable output", false)
+      .action(async (opts: { workspace?: string; server?: string; apply?: boolean; force?: boolean; json?: boolean }) => {
+        await mcpScaffoldMapping({
+          workspace: opts.workspace,
+          serverId: String(opts.server),
+          apply: Boolean(opts.apply),
+          force: Boolean(opts.force),
+          json: Boolean(opts.json)
+        });
+      })
   );
 
 program

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -53,6 +53,25 @@ function readYamlFile(filePath: string): unknown {
   }
 }
 
+function safeSlug(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 32);
+}
+
+function scaffoldCapabilityId(serverId: string, toolName: string): string {
+  // If the MCP tool name already matches mar21's capability-id convention, preserve it.
+  const normalized = toolName.trim();
+  if (/^[a-z0-9]+\.[a-z0-9]+\.[a-z0-9_.-]+\.[a-z0-9_.-]+$/.test(normalized)) return normalized;
+
+  // Otherwise generate a placeholder that validates and is easy to edit.
+  // Convention: `<serverId>.read.mcp_tool.<slug>`
+  return `${safeSlug(serverId) || "mcp"}.read.mcp_tool.${safeSlug(normalized) || "tool"}`;
+}
+
 function asMcpCliError(action: string, serverId: string, err: unknown): Error & { exitCode?: number } {
   const msg = err instanceof Error ? err.message : String(err);
   const hints: string[] = [];
@@ -162,6 +181,97 @@ export async function mcpTools(opts: { workspace?: string; serverId: string; jso
     return;
   }
   for (const t of tools) console.log(`- ${t.name}${t.description ? ` — ${t.description}` : ""}`);
+}
+
+export async function mcpScaffoldMapping(opts: {
+  workspace?: string;
+  serverId: string;
+  apply?: boolean;
+  force?: boolean;
+  json?: boolean;
+}): Promise<void> {
+  const repoRoot = repoRootFromCwd();
+  const workspaceId = resolveWorkspaceId(opts.workspace);
+  if (!workspaceId) {
+    const err = new Error("missing --workspace (or MAR21_WORKSPACE)");
+    (err as Error & { exitCode?: number }).exitCode = 2;
+    throw err;
+  }
+
+  const wsRoot = requireWorkspaceRoot(repoRoot, workspaceId);
+  loadWorkspaceSecretsIntoEnv(wsRoot);
+  const cfgPath = path.join(wsRoot, "_cfg", "mcp-servers.yaml");
+
+  const cfg = loadMcpServersFile(wsRoot);
+  if (!cfg) {
+    const err = new Error(`missing MCP servers config: ${cfgPath}`);
+    (err as Error & { exitCode?: number }).exitCode = 10;
+    throw err;
+  }
+
+  const server = cfg.servers.find((s) => s.id === opts.serverId);
+  if (!server) {
+    const err = new Error(`mcp server not found: ${opts.serverId}`) as Error & { exitCode?: number };
+    err.exitCode = 2;
+    throw err;
+  }
+
+  let tools: Array<{ name: string; description?: string }> = [];
+  try {
+    tools = await listMcpToolsIsolated(server as any);
+  } catch (e) {
+    throw asMcpCliError("scaffold-mapping (tools)", opts.serverId, e);
+  }
+
+  const mappings = tools.map((t) => ({
+    capabilityId: scaffoldCapabilityId(server.id, t.name),
+    toolName: t.name
+  }));
+
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify({ workspace: workspaceId, server: server.id, mappings })}\n`);
+    return;
+  }
+
+  const snippet = YAML.stringify({ capabilities: mappings });
+  if (!opts.apply) {
+    process.stdout.write(`# Paste into: workspaces/${workspaceId}/_cfg/mcp-servers.yaml (server: ${server.id})\n`);
+    process.stdout.write(snippet);
+    return;
+  }
+
+  // Apply into config (rewrite YAML, may drop comments/formatting).
+  const doc = readYamlFile(cfgPath) as any;
+  if (!doc || typeof doc !== "object") {
+    const err = new Error(`invalid YAML (expected object): ${cfgPath}`) as Error & { exitCode?: number };
+    err.exitCode = 11;
+    throw err;
+  }
+  if (doc.apiVersion !== "mar21/mcp-servers-v1" || !Array.isArray(doc.servers)) {
+    const err = new Error(`unsupported mcp-servers.yaml format: ${cfgPath}`) as Error & { exitCode?: number };
+    err.exitCode = 11;
+    throw err;
+  }
+
+  const idx = doc.servers.findIndex((s: any) => s?.id === server.id);
+  if (idx === -1) {
+    const err = new Error(`mcp server not found in yaml: ${server.id}`) as Error & { exitCode?: number };
+    err.exitCode = 11;
+    throw err;
+  }
+
+  const existing = Array.isArray(doc.servers[idx].capabilities) ? doc.servers[idx].capabilities : [];
+  if (existing.length > 0 && !opts.force) {
+    // Merge: keep existing entries and add new tool names not present yet.
+    const existingToolNames = new Set(existing.map((e: any) => (e?.toolName ? String(e.toolName) : "")));
+    const merged = [...existing, ...mappings.filter((m) => !existingToolNames.has(m.toolName))];
+    doc.servers[idx].capabilities = merged;
+  } else {
+    doc.servers[idx].capabilities = mappings;
+  }
+
+  fs.writeFileSync(cfgPath, YAML.stringify(doc), "utf-8");
+  console.log(`✓ wrote capability mappings to: ${path.relative(repoRoot, cfgPath)}`);
 }
 
 export async function mcpCall(opts: {


### PR DESCRIPTION
Closes #55

## What
- Adds `mar21 mcp scaffold-mapping --workspace <ws> --server <id>` to generate a starter `capabilities:` mapping from discovered MCP tool names.
- Supports `--apply` (writes into `_cfg/mcp-servers.yaml`, rewrites YAML) and `--force` (overwrite existing capabilities).
- Updates docs (`docs/CLI.md`, `docs/MCP.md`).

## Manual tests
- `pnpm build`
- `node packages/cli/dist/index.js validate --examples`
- If server not configured/authenticated, command fails cleanly with exit `20` and an actionable hint.