### PR TITLE
UX: marketer-mode session + show

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This repo specifies an opinionated CLI, even before code exists:
 
 ```bash
 mar21 init --workspace acme --stack default
+mar21 session --workspace acme
+mar21 show latest research_pack --workspace acme
 mar21 plan gtm --workspace acme
 
 mar21 analyze week --workspace acme

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -8,6 +8,9 @@ This document defines the **exact** CLI surface and UX expectations. Implementer
 ```
 mar21 init --workspace <id> [--stack <preset>] [--connectors <list>] [--force]
 
+mar21 session [--workspace <id>] [--since <duration>] [--mode <mode>]
+mar21 start [--workspace <id>] [--since <duration>] [--mode <mode>]   # alias for session
+
 mar21 plan <workflowId> --workspace <id> [--request <path>] [--mode <mode>] [--since <duration>] [--dry-run] [--json]
 mar21 analyze <scope> --workspace <id> [--mode <mode>] [--since <duration>] [--dry-run] [--json]
 mar21 report <cadence|workflowId> --workspace <id> [--since <duration>] [--json]
@@ -16,6 +19,8 @@ mar21 run daily|weekly|monthly --workspace <id> [--profile <profileId>] [--mode 
 mar21 autopilot start --workspace <id> --profile <profileId> [--mode <mode>] [--dry-run] [--foreground]
 
 mar21 apply <runId> --workspace <id> [--yes] [--fail-on-reject] [--json]
+
+mar21 show <runId|latest> <artifact> --workspace <id>
 
 mar21 mcp doctor --workspace <id> [--json]
 mar21 mcp tools --workspace <id> --server <serverId> [--json]

--- a/packages/cli/src/apply-engine.ts
+++ b/packages/cli/src/apply-engine.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import process from "node:process";
 import readline from "node:readline/promises";
 import { ensureDir, readYamlFile, resolveWorkspaceId, writeYamlFile } from "./workspace.js";
+import { resolveRepoRoot } from "./repo-root.js";
 
 type ChangeSetOp = {
   id: string;
@@ -70,7 +71,7 @@ function nowIso(): string {
 }
 
 function repoRootFromCwd(): string {
-  return process.cwd();
+  return resolveRepoRoot(process.cwd());
 }
 
 function safeJoin(baseDir: string, relativePath: string): string {

--- a/packages/cli/src/autopilot.ts
+++ b/packages/cli/src/autopilot.ts
@@ -3,6 +3,7 @@ import { loadProfile, profilePathFor } from "./profile.js";
 import { runPlan, RunSummary } from "./run-engine.js";
 import { Mode, resolveWorkspaceId, workspaceRoot } from "./workspace.js";
 import fs from "node:fs";
+import { resolveRepoRoot } from "./repo-root.js";
 
 export type AutopilotOptions = {
   workspace?: string;
@@ -13,7 +14,7 @@ export type AutopilotOptions = {
 };
 
 function repoRootFromCwd(): string {
-  return process.cwd();
+  return resolveRepoRoot(process.cwd());
 }
 
 function intervalMsForProfile(profileId: string): number {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,8 @@ import { initWorkspace } from "./init.js";
 import { mcpCall, mcpDoctor, mcpScaffoldMapping, mcpTools } from "./mcp.js";
 import { runCadence } from "./run-cadence.js";
 import { runAnalyze, runPlan, runReport } from "./run-engine.js";
+import { runSession } from "./session.js";
+import { showArtifact } from "./show.js";
 import { validateExamples } from "./validate.js";
 
 process.on("uncaughtException", (err) => {
@@ -67,6 +69,31 @@ program
       console.log(`✓ workspace initialized: ${res.workspace} (${res.root})`);
     }
   );
+
+program
+  .command("session")
+  .alias("start")
+  .description("Run a guided marketer-mode session (v0.1)")
+  .option("--workspace <id>", "Workspace id (will prompt if omitted)")
+  .option("--since <duration>", "ISO 8601 duration, e.g. P7D or P28D", undefined)
+  .option("--mode <mode>", "advisory|supervised|autonomous", undefined)
+  .action(async (opts: { workspace?: string; since?: string; mode?: string }) => {
+    const mode =
+      opts.mode === "advisory" || opts.mode === "supervised" || opts.mode === "autonomous"
+        ? opts.mode
+        : undefined;
+    await runSession({ workspace: opts.workspace, since: opts.since, mode });
+  });
+
+program
+  .command("show")
+  .description("Print an artifact to stdout (marketer-friendly)")
+  .argument("<runId>", "Run id, or 'latest'")
+  .argument("<artifact>", "research_pack|report|plan|decision_log|changeset|todos|context|creative_brief")
+  .option("--workspace <id>", "Workspace id")
+  .action((runId: string, artifact: string, opts: { workspace?: string }) => {
+    process.exit(showArtifact({ workspace: opts.workspace, runId, artifact }));
+  });
 
 program
   .command("validate")

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import process from "node:process";
 import YAML from "yaml";
 import { ensureDir } from "./workspace.js";
+import { resolveRepoRoot } from "./repo-root.js";
 
 export type InitOptions = {
   workspace?: string;
@@ -11,19 +12,17 @@ export type InitOptions = {
   force?: boolean;
 };
 
-function findRepoRootFromCwd(): string | null {
-  let dir = process.cwd();
-  for (let i = 0; i < 25; i += 1) {
-    const packagesDir = path.join(dir, "packages");
-    const schemasDir = path.join(dir, "schemas");
-    const docsDir = path.join(dir, "docs");
-    if (fs.existsSync(packagesDir) && fs.existsSync(schemasDir) && fs.existsSync(docsDir)) return dir;
+function looksLikeRepoRoot(dir: string): boolean {
+  const packagesDir = path.join(dir, "packages");
+  const schemasDir = path.join(dir, "schemas");
+  const docsDir = path.join(dir, "docs");
+  const workspacesDir = path.join(dir, "workspaces");
+  return fs.existsSync(packagesDir) && fs.existsSync(schemasDir) && fs.existsSync(docsDir) && fs.existsSync(workspacesDir);
+}
 
-    const parent = path.dirname(dir);
-    if (parent === dir) return null;
-    dir = parent;
-  }
-  return null;
+function findRepoRootFromCwd(): string | null {
+  const resolved = resolveRepoRoot(process.cwd());
+  return looksLikeRepoRoot(resolved) ? resolved : null;
 }
 
 function validateWorkspaceId(id: string): boolean {
@@ -279,6 +278,13 @@ export function initWorkspace(opts: InitOptions): { workspace: string; root: str
   }
 
   const repoRoot = findRepoRootFromCwd() ?? process.cwd();
+  if (!looksLikeRepoRoot(repoRoot)) {
+    const err = new Error(
+      "could not locate mar21 repo root (expected packages/, schemas/, docs/, workspaces/). Run from inside the repo."
+    ) as Error & { exitCode?: number };
+    err.exitCode = 10;
+    throw err;
+  }
   const wsRoot = path.join(repoRoot, "workspaces", workspaceId);
 
   if (fs.existsSync(wsRoot)) {

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -6,6 +6,7 @@ import process from "node:process";
 import YAML from "yaml";
 import { callMcpToolIsolated, listMcpToolsIsolated, loadMcpServersFile, loadWorkspaceSecretsIntoEnv } from "@mar21/mcp";
 import { requireWorkspaceRoot, resolveWorkspaceId } from "./workspace.js";
+import { resolveRepoRoot } from "./repo-root.js";
 
 type Ajv2020Class = typeof import("ajv/dist/2020.js").default;
 type Ajv2020Instance = InstanceType<Ajv2020Class>;
@@ -15,7 +16,7 @@ const addFormats = ((addFormatsImport as unknown as { default?: unknown }).defau
   addFormatsImport) as unknown as (ajv: Ajv2020Instance) => void;
 
 function repoRootFromCwd(): string {
-  return process.cwd();
+  return resolveRepoRoot(process.cwd());
 }
 
 function loadJsonFile(filePath: string): unknown {

--- a/packages/cli/src/repo-root.ts
+++ b/packages/cli/src/repo-root.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+export function resolveRepoRoot(startDir: string = process.cwd()): string {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < 25; i += 1) {
+    const marker = path.join(dir, "pnpm-workspace.yaml");
+    const pkg = path.join(dir, "package.json");
+    const packagesDir = path.join(dir, "packages");
+    const workspacesDir = path.join(dir, "workspaces");
+    if (fs.existsSync(marker) && fs.existsSync(pkg) && fs.existsSync(packagesDir) && fs.existsSync(workspacesDir)) {
+      return dir;
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return path.resolve(startDir);
+}
+

--- a/packages/cli/src/run-cadence.ts
+++ b/packages/cli/src/run-cadence.ts
@@ -4,6 +4,7 @@ import process from "node:process";
 import { loadProfile, profilePathFor } from "./profile.js";
 import { runPlan, RunSummary } from "./run-engine.js";
 import { Mode, resolveWorkspaceId, workspaceRoot } from "./workspace.js";
+import { resolveRepoRoot } from "./repo-root.js";
 
 export type RunCadenceOptions = {
   cadence: "daily" | "weekly" | "monthly";
@@ -22,7 +23,7 @@ export type RunCadenceSummary = {
 };
 
 function repoRootFromCwd(): string {
-  return process.cwd();
+  return resolveRepoRoot(process.cwd());
 }
 
 export async function runCadence(opts: RunCadenceOptions): Promise<RunCadenceSummary> {

--- a/packages/cli/src/run-engine.ts
+++ b/packages/cli/src/run-engine.ts
@@ -21,6 +21,7 @@ import {
   utcTimestampForRunId,
   workspaceRoot
 } from "./workspace.js";
+import { resolveRepoRoot } from "./repo-root.js";
 
 export type RunSummary = {
   runId: string;
@@ -41,7 +42,7 @@ export type PlanCommandOptions = {
 };
 
 function repoRootFromCwd(): string {
-  return process.cwd();
+  return resolveRepoRoot(process.cwd());
 }
 
 function pickRunId(runsDir: string, baseRunId: string): string {

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -1,0 +1,222 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import readline from "node:readline/promises";
+import { initWorkspace } from "./init.js";
+import { applyRunChangeset } from "./apply-engine.js";
+import { runPlan } from "./run-engine.js";
+import { resolveRepoRoot } from "./repo-root.js";
+import { defaultModeFromContext, readYamlFile, resolveWorkspaceId, workspaceRoot, writeYamlFile, type Mode } from "./workspace.js";
+
+type SessionOptions = {
+  workspace?: string;
+  since?: string;
+  mode?: Mode;
+};
+
+function validateWorkspaceId(id: string): boolean {
+  return /^[a-z0-9][a-z0-9-]{1,31}$/.test(id);
+}
+
+async function promptText(prompt: string, defaultValue?: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const suffix = defaultValue ? ` (${defaultValue})` : "";
+    const answer = (await rl.question(`${prompt}${suffix}: `)).trim();
+    return answer.length > 0 ? answer : defaultValue ?? "";
+  } finally {
+    rl.close();
+  }
+}
+
+async function promptYesNo(prompt: string, defaultYes = true): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const hint = defaultYes ? "Y/n" : "y/N";
+    const answer = (await rl.question(`${prompt} (${hint}) `)).trim().toLowerCase();
+    if (!answer) return defaultYes;
+    return answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+function extractDriveId(raw: string): { kind: "file" | "folder"; id: string } | null {
+  const s = raw.trim();
+  if (!s) return null;
+
+  const urlMatch = (() => {
+    const m1 = /\/drive\/folders\/([a-zA-Z0-9_-]{10,})/.exec(s);
+    if (m1) return { kind: "folder" as const, id: m1[1] };
+    const m2 = /\/file\/d\/([a-zA-Z0-9_-]{10,})/.exec(s);
+    if (m2) return { kind: "file" as const, id: m2[1] };
+    const m3 = /\/document\/d\/([a-zA-Z0-9_-]{10,})/.exec(s);
+    if (m3) return { kind: "file" as const, id: m3[1] };
+    const m4 = /\/spreadsheets\/d\/([a-zA-Z0-9_-]{10,})/.exec(s);
+    if (m4) return { kind: "file" as const, id: m4[1] };
+    const m5 = /\/presentation\/d\/([a-zA-Z0-9_-]{10,})/.exec(s);
+    if (m5) return { kind: "file" as const, id: m5[1] };
+    const m6 = /[?&]id=([a-zA-Z0-9_-]{10,})/.exec(s);
+    if (m6) return { kind: "file" as const, id: m6[1] };
+    return null;
+  })();
+  if (urlMatch) return urlMatch;
+
+  if (/^[a-zA-Z0-9_-]{10,}$/.test(s)) return { kind: "file", id: s };
+  return null;
+}
+
+function readContextSafe(contextPath: string): any {
+  if (!fs.existsSync(contextPath)) return null;
+  try {
+    return readYamlFile(contextPath) as any;
+  } catch {
+    return null;
+  }
+}
+
+export async function runSession(opts: SessionOptions): Promise<void> {
+  const canPrompt = Boolean(process.stdin.isTTY);
+  const repoRoot = resolveRepoRoot(process.cwd());
+
+  let workspaceId = resolveWorkspaceId(opts.workspace) ?? null;
+  if (!workspaceId) {
+    if (!canPrompt) {
+      const err = new Error("missing --workspace (or MAR21_WORKSPACE)") as Error & { exitCode?: number };
+      err.exitCode = 2;
+      throw err;
+    }
+    workspaceId = await promptText("Workspace name", "default");
+  }
+  workspaceId = workspaceId.trim();
+  if (!validateWorkspaceId(workspaceId)) {
+    const err = new Error(
+      `invalid workspace id: ${workspaceId} (expected letters/numbers/dashes, 2–32 chars)`
+    ) as Error & { exitCode?: number };
+    err.exitCode = 2;
+    throw err;
+  }
+
+  const wsRoot = workspaceRoot(repoRoot, workspaceId);
+  if (!fs.existsSync(wsRoot)) {
+    if (!canPrompt) {
+      const err = new Error(`workspace not found: ${workspaceId} (${wsRoot})`) as Error & { exitCode?: number };
+      err.exitCode = 10;
+      throw err;
+    }
+    const create = await promptYesNo(`No workspace '${workspaceId}' found. Create it now?`, true);
+    if (!create) {
+      const err = new Error("session canceled") as Error & { exitCode?: number };
+      err.exitCode = 10;
+      throw err;
+    }
+    const stack = await promptText("Which stack preset? (default/content_engine/paid_growth/lifecycle)", "default");
+    initWorkspace({ workspace: workspaceId, stack, force: false });
+  }
+
+  const contextPath = path.join(wsRoot, "marketing-context.yaml");
+  const existingContext = readContextSafe(contextPath);
+  const mode = (opts.mode ?? defaultModeFromContext(existingContext)) as Mode;
+  const since = opts.since ?? "P28D";
+
+  process.stdout.write("\nmar21 session — marketer mode (v0.1)\n");
+  process.stdout.write("You answer a few questions; mar21 generates evidence-backed artifacts + a task backlog.\n\n");
+
+  const companyNameDefault =
+    typeof existingContext?.company?.name === "string" && existingContext.company.name.trim()
+      ? existingContext.company.name.trim()
+      : workspaceId;
+  const companyName = canPrompt ? await promptText("What are we working on? (company/product name)", companyNameDefault) : companyNameDefault;
+
+  const primaryKpiDefault =
+    typeof existingContext?.goals?.primaryKpi === "string" && existingContext.goals.primaryKpi.trim()
+      ? existingContext.goals.primaryKpi.trim()
+      : "leads";
+  const primaryKpi = canPrompt ? await promptText("Primary KPI (leads/pipeline/revenue/traffic)", primaryKpiDefault) : primaryKpiDefault;
+
+  const objective = canPrompt
+    ? await promptText("What outcome do you want from this session? (1 sentence)", "Tighten positioning + ship next-week plan")
+    : "Tighten positioning + ship next-week plan";
+
+  const updateContext = canPrompt ? await promptYesNo("Update your workspace context with these answers?", true) : true;
+  if (updateContext) {
+    const next = (existingContext && typeof existingContext === "object" ? { ...(existingContext as any) } : {}) as any;
+    next.apiVersion = next.apiVersion ?? "mar21/v1";
+    next.workspace = next.workspace ?? workspaceId;
+    next.company = { ...(next.company ?? {}), name: companyName };
+    next.goals = { ...(next.goals ?? {}), primaryKpi };
+    writeYamlFile(contextPath, next);
+  }
+
+  const includeDrive = canPrompt ? await promptYesNo("Include private docs from Google Drive as sources?", false) : false;
+  const driveSel = (() => {
+    if (!includeDrive) return null;
+    return { fileIds: [] as string[], folderIds: [] as string[], query: null as string | null, limits: { maxDownloads: 5, maxFileSizeMB: 25 } };
+  })();
+
+  if (driveSel && canPrompt) {
+    const raw = await promptText("Paste a Drive link (file or folder) or an id (you can paste multiple, comma-separated)", "");
+    const parts = raw
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean);
+    for (const p of parts) {
+      const hit = extractDriveId(p);
+      if (!hit) continue;
+      if (hit.kind === "folder") driveSel.folderIds.push(hit.id);
+      else driveSel.fileIds.push(hit.id);
+    }
+
+    if (driveSel.fileIds.length === 0 && driveSel.folderIds.length === 0) {
+      const addQuery = await promptYesNo("No Drive ids detected. Use a Drive search query instead?", false);
+      if (addQuery) {
+        driveSel.query = await promptText("Drive query (example: name contains 'positioning')", "name contains 'positioning'");
+      }
+    }
+
+    const maxDownloadsRaw = await promptText("Safety cap: max downloads", String(driveSel.limits.maxDownloads));
+    const maxDownloads = Number(maxDownloadsRaw);
+    if (Number.isFinite(maxDownloads) && maxDownloads >= 0) driveSel.limits.maxDownloads = maxDownloads;
+  }
+
+  process.stdout.write("\nRunning: Deep Research + Sparring…\n");
+  const researchRun = await runPlan("deep_research_sparring", {
+    workspace: workspaceId,
+    mode,
+    since,
+    params: {
+      research: {
+        objective,
+        sources: {
+          drive: driveSel ? { ...driveSel } : undefined
+        }
+      }
+    }
+  });
+
+  process.stdout.write(`✓ Research run created: ${researchRun.runId}\n`);
+  process.stdout.write(`  Read it: mar21 show ${researchRun.runId} research_pack --workspace ${workspaceId}\n`);
+
+  const applyNow = canPrompt ? await promptYesNo("Add suggested tasks to your backlog now?", true) : false;
+  if (applyNow) {
+    const applied = await applyRunChangeset({ workspace: workspaceId, runId: researchRun.runId });
+    if (applied.exitCode !== 0) {
+      const err = new Error("apply had failures (see logs in the run folder)") as Error & { exitCode?: number };
+      err.exitCode = applied.exitCode;
+      throw err;
+    }
+    process.stdout.write("✓ Backlog updated (todos.yaml)\n");
+  } else {
+    process.stdout.write(`(Skipped apply) You can apply later: mar21 apply ${researchRun.runId} --workspace ${workspaceId}\n`);
+  }
+
+  const doBrief = canPrompt ? await promptYesNo("Generate a landing page creative brief now?", true) : false;
+  if (doBrief) {
+    const briefRun = await runPlan("content_brief", { workspace: workspaceId, mode, since: "P0D" });
+    process.stdout.write(`✓ Creative brief generated: ${briefRun.runId}\n`);
+    process.stdout.write(`  Show it: mar21 show ${briefRun.runId} creative_brief --workspace ${workspaceId}\n`);
+  }
+
+  process.stdout.write("\nDone.\n");
+  process.stdout.write(`Next: mar21 show latest todos --workspace ${workspaceId}\n`);
+}

--- a/packages/cli/src/show.ts
+++ b/packages/cli/src/show.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { resolveRepoRoot } from "./repo-root.js";
+import { resolveWorkspaceId, workspaceRoot } from "./workspace.js";
+
+type ShowOptions = {
+  workspace?: string;
+  runId: string;
+  artifact: string;
+};
+
+function latestRunId(runsDir: string): string | null {
+  if (!fs.existsSync(runsDir)) return null;
+  const entries = fs
+    .readdirSync(runsDir)
+    .filter((e) => !e.startsWith("."))
+    .sort();
+  return entries.length ? entries[entries.length - 1] : null;
+}
+
+function runsNewestFirst(runsDir: string): string[] {
+  if (!fs.existsSync(runsDir)) return [];
+  return fs
+    .readdirSync(runsDir)
+    .filter((e) => !e.startsWith("."))
+    .sort()
+    .reverse();
+}
+
+function artifactPath(opts: { wsRoot: string; runId: string; artifact: string }): string {
+  const a = opts.artifact.trim().toLowerCase();
+  if (a === "todos" || a === "todo" || a === "tasks") return path.join(opts.wsRoot, "todos.yaml");
+  if (a === "context" || a === "marketing-context") return path.join(opts.wsRoot, "marketing-context.yaml");
+  if (a === "changeset") return path.join(opts.wsRoot, "runs", opts.runId, "changeset.yaml");
+  if (a === "plan") return path.join(opts.wsRoot, "runs", opts.runId, "outputs", "plan.md");
+  if (a === "report") return path.join(opts.wsRoot, "runs", opts.runId, "outputs", "report.md");
+  if (a === "research_pack" || a === "research" || a === "research-pack")
+    return path.join(opts.wsRoot, "runs", opts.runId, "outputs", "research_pack.md");
+  if (a === "decision_log" || a === "decisions" || a === "decision-log")
+    return path.join(opts.wsRoot, "runs", opts.runId, "outputs", "decision_log.md");
+  if (a === "creative_brief" || a === "brief" || a === "creative-brief")
+    return path.join(opts.wsRoot, "runs", opts.runId, "outputs", "creative_brief.yaml");
+  const err = new Error(
+    `unknown artifact: ${opts.artifact} (try: research_pack, report, plan, decision_log, changeset, todos, context, creative_brief)`
+  ) as Error & { exitCode?: number };
+  err.exitCode = 2;
+  throw err;
+}
+
+export function showArtifact(opts: ShowOptions): number {
+  const repoRoot = resolveRepoRoot(process.cwd());
+  const workspaceId = resolveWorkspaceId(opts.workspace);
+  if (!workspaceId) {
+    const err = new Error("missing --workspace (or MAR21_WORKSPACE)") as Error & { exitCode?: number };
+    err.exitCode = 2;
+    throw err;
+  }
+
+  const wsRoot = workspaceRoot(repoRoot, workspaceId);
+  if (!fs.existsSync(wsRoot) || !fs.statSync(wsRoot).isDirectory()) {
+    const err = new Error(`workspace not found: ${workspaceId}`) as Error & { exitCode?: number };
+    err.exitCode = 10;
+    throw err;
+  }
+
+  const runId = (() => {
+    const raw = opts.runId.trim();
+    if (raw === "latest" || raw === "last") {
+      const runsDir = path.join(wsRoot, "runs");
+      const candidates = runsNewestFirst(runsDir);
+      if (candidates.length === 0) {
+        const err = new Error(`no runs found for workspace: ${workspaceId}`) as Error & { exitCode?: number };
+        err.exitCode = 10;
+        throw err;
+      }
+
+      // Prefer the newest run that actually contains the requested artifact.
+      for (const id of candidates) {
+        try {
+          const p = artifactPath({ wsRoot, runId: id, artifact: opts.artifact });
+          if (fs.existsSync(p)) return id;
+        } catch {
+          // ignore; handled later
+        }
+      }
+
+      // Fall back to newest run (gives a good error message with the exact path).
+      return candidates[0];
+    }
+    return raw;
+  })();
+
+  const p = artifactPath({ wsRoot, runId, artifact: opts.artifact });
+  if (!fs.existsSync(p)) {
+    const err = new Error(`artifact not found: ${opts.artifact} (${p})`) as Error & { exitCode?: number };
+    err.exitCode = 10;
+    throw err;
+  }
+
+  process.stdout.write(fs.readFileSync(p, "utf-8"));
+  if (!process.stdout.write("")) return 0;
+  return 0;
+}

--- a/packages/cli/src/workspace.ts
+++ b/packages/cli/src/workspace.ts
@@ -36,8 +36,10 @@ export function requireWorkspaceRoot(repoRoot: string, workspaceId: string): str
   if (!fs.existsSync(wsRoot) || !fs.statSync(wsRoot).isDirectory()) {
     const err = new Error(`workspace not found: ${workspaceId} (${wsRoot})`) as Error & {
       code?: string;
+      exitCode?: number;
     };
     err.code = "MAR21_WORKSPACE_NOT_FOUND";
+    err.exitCode = 10;
     throw err;
   }
   return wsRoot;


### PR DESCRIPTION
Closes #57.

What
- Adds a marketer-friendly entrypoint: `mar21 session` (alias `mar21 start`).
  - Prompts for a few plain-language inputs (when interactive).
  - Runs `deep_research_sparring` and offers to apply the ChangeSet to create tasks.
  - Optionally generates a landing page creative brief (`content_brief`).
- Adds `mar21 show <runId|latest> <artifact>` to print artifacts without digging through folders.
- Makes the CLI runnable from any directory by resolving the repo root automatically.

Manual test
- `pnpm build`
- `node packages/cli/dist/index.js session --workspace mar21-self --since P7D`
- `node packages/cli/dist/index.js show latest research_pack --workspace mar21-self`

Notes
- `show latest` finds the newest run that actually contains the requested artifact.
