### PR TITLE
UX: marketer-mode polish + MCP add wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ mar21 run weekly --workspace acme
 mar21 autopilot start --profile daily --workspace acme
 ```
 
+If you’re working inside this repo, you can run the CLI via:
+
+```bash
+pnpm -s build
+pnpm mar21 start --workspace acme
+```
+
 ## License
 Apache-2.0 — see `LICENSE`.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -22,6 +22,7 @@ mar21 apply <runId> --workspace <id> [--yes] [--fail-on-reject] [--json]
 
 mar21 show <runId|latest> <artifact> --workspace <id>
 
+mar21 mcp add --workspace <id>
 mar21 mcp doctor --workspace <id> [--json]
 mar21 mcp tools --workspace <id> --server <serverId> [--json]
 mar21 mcp call --workspace <id> --server <serverId> --tool <toolName> --input <json> [--json]

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -26,6 +26,7 @@ This unlocks the core goal: a one-person marketing cockpit where your agent can 
 
 ## CLI
 Use these for “bring your own server” debugging:
+- `mar21 mcp add --workspace <id>`: add a server entry via a wizard (no YAML editing)
 - `mar21 mcp doctor --workspace <id>`: schema validation + basic sanity checks
 - `mar21 mcp tools --workspace <id> --server <serverId>`: list tools (stdio only)
 - `mar21 mcp call --workspace <id> --server <serverId> --tool <toolName> --input <json>`: call tool (stdio only)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "pnpm -C packages/cli dev",
     "lint": "echo \"lint: TODO\"",
     "test": "echo \"test: TODO\"",
-    "validate": "pnpm -C packages/cli dev -- validate --examples"
+    "validate": "pnpm -C packages/cli dev -- validate --examples",
+    "mar21": "node packages/cli/dist/index.js"
   }
 }
-

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { applyRunChangeset } from "./apply-engine.js";
 import { autopilotStart } from "./autopilot.js";
 import { initWorkspace } from "./init.js";
 import { mcpCall, mcpDoctor, mcpScaffoldMapping, mcpTools } from "./mcp.js";
+import { mcpAddServer } from "./mcp-add.js";
 import { runCadence } from "./run-cadence.js";
 import { runAnalyze, runPlan, runReport } from "./run-engine.js";
 import { runSession } from "./session.js";
@@ -107,6 +108,14 @@ program
 program
   .command("mcp")
   .description("MCP utilities (v0.1: stdio transport)")
+  .addCommand(
+    new Command("add")
+      .description("Add an MCP server to this workspace (wizard)")
+      .option("--workspace <id>", "Workspace id")
+      .action(async (opts: { workspace?: string }) => {
+        await mcpAddServer({ workspace: opts.workspace });
+      })
+  )
   .addCommand(
     new Command("doctor")
       .description("Validate workspace MCP server config")

--- a/packages/cli/src/mcp-add.ts
+++ b/packages/cli/src/mcp-add.ts
@@ -1,0 +1,199 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import readline from "node:readline/promises";
+import YAML from "yaml";
+import { resolveRepoRoot } from "./repo-root.js";
+import { ensureDir, resolveWorkspaceId, workspaceRoot } from "./workspace.js";
+
+type McpServersFile = {
+  apiVersion: "mar21/mcp-servers-v1";
+  servers: Array<{
+    id: string;
+    transport: "stdio" | "http";
+    command?: string;
+    args?: string[];
+    cwd?: string;
+    env?: Record<string, string>;
+    capabilities?: Array<{ capabilityId: string; toolName: string }>;
+    url?: string;
+    notes?: string;
+  }>;
+};
+
+async function promptText(prompt: string, defaultValue?: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const suffix = defaultValue ? ` (${defaultValue})` : "";
+    const answer = (await rl.question(`${prompt}${suffix}: `)).trim();
+    return answer.length > 0 ? answer : defaultValue ?? "";
+  } finally {
+    rl.close();
+  }
+}
+
+async function promptYesNo(prompt: string, defaultYes = true): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const hint = defaultYes ? "Y/n" : "y/N";
+    const answer = (await rl.question(`${prompt} (${hint}) `)).trim().toLowerCase();
+    if (!answer) return defaultYes;
+    return answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+function parseCommandLine(cmdline: string): { command: string; args: string[] } {
+  const s = cmdline.trim();
+  if (!s) {
+    const err = new Error("missing command line") as Error & { exitCode?: number };
+    err.exitCode = 2;
+    throw err;
+  }
+
+  const args: string[] = [];
+  let cur = "";
+  let quote: "'" | "\"" | null = null;
+  let escaped = false;
+
+  const push = () => {
+    const t = cur.trim();
+    if (t.length > 0) args.push(t);
+    cur = "";
+  };
+
+  for (let i = 0; i < s.length; i += 1) {
+    const ch = s[i]!;
+    if (escaped) {
+      cur += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      else cur += ch;
+      continue;
+    }
+    if (ch === "'" || ch === "\"") {
+      quote = ch as any;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      push();
+      continue;
+    }
+    cur += ch;
+  }
+  push();
+
+  const command = args.shift();
+  if (!command) {
+    const err = new Error("invalid command line") as Error & { exitCode?: number };
+    err.exitCode = 2;
+    throw err;
+  }
+  return { command, args };
+}
+
+function readMcpServersFile(filePath: string): McpServersFile {
+  if (!fs.existsSync(filePath)) return { apiVersion: "mar21/mcp-servers-v1", servers: [] };
+  const doc = YAML.parse(fs.readFileSync(filePath, "utf-8")) as any;
+  if (doc && typeof doc === "object" && doc.apiVersion === "mar21/mcp-servers-v1" && Array.isArray(doc.servers)) {
+    return { apiVersion: "mar21/mcp-servers-v1", servers: doc.servers as any[] };
+  }
+  const err = new Error(`unsupported mcp-servers.yaml format: ${filePath}`) as Error & { exitCode?: number };
+  err.exitCode = 10;
+  throw err;
+}
+
+function validServerId(id: string): boolean {
+  return /^[a-z0-9][a-z0-9_.-]{0,63}$/.test(id);
+}
+
+function parseEnvPairs(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const part of raw.split(",").map((p) => p.trim()).filter(Boolean)) {
+    const idx = part.indexOf("=");
+    if (idx === -1) continue;
+    const k = part.slice(0, idx).trim();
+    const v = part.slice(idx + 1).trim();
+    if (!k) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+export async function mcpAddServer(opts: { workspace?: string }): Promise<void> {
+  if (!process.stdin.isTTY) {
+    const err = new Error("mcp add requires an interactive terminal (TTY)") as Error & { exitCode?: number };
+    err.exitCode = 2;
+    throw err;
+  }
+
+  const repoRoot = resolveRepoRoot(process.cwd());
+  const workspaceId = resolveWorkspaceId(opts.workspace);
+  if (!workspaceId) {
+    const err = new Error("missing --workspace (or MAR21_WORKSPACE)") as Error & { exitCode?: number };
+    err.exitCode = 2;
+    throw err;
+  }
+
+  const wsRoot = workspaceRoot(repoRoot, workspaceId);
+  if (!fs.existsSync(wsRoot) || !fs.statSync(wsRoot).isDirectory()) {
+    const err = new Error(`workspace not found: ${workspaceId}`) as Error & { exitCode?: number };
+    err.exitCode = 10;
+    throw err;
+  }
+
+  ensureDir(path.join(wsRoot, "_cfg"));
+  const cfgPath = path.join(wsRoot, "_cfg", "mcp-servers.yaml");
+  const cfg = readMcpServersFile(cfgPath);
+
+  const serverId = (await promptText("Server id (lowercase, e.g. 'gdrive' or 'ahrefs')", "custom")).trim();
+  if (!validServerId(serverId)) {
+    const err = new Error(
+      `invalid server id: ${serverId} (expected /^[a-z0-9][a-z0-9_.-]{0,63}$/)`
+    ) as Error & { exitCode?: number };
+    err.exitCode = 2;
+    throw err;
+  }
+  if (cfg.servers.some((s) => s.id === serverId)) {
+    const overwrite = await promptYesNo(`Server '${serverId}' already exists. Overwrite it?`, false);
+    if (!overwrite) return;
+  }
+
+  const cmdline = await promptText("Paste stdio command (example: npx -y @modelcontextprotocol/server-gdrive)", "");
+  const parsed = parseCommandLine(cmdline);
+
+  const envRaw = await promptText("Optional env (comma-separated KEY=value, leave blank for none)", "");
+  const env = envRaw.trim().length > 0 ? parseEnvPairs(envRaw) : {};
+  const notes = await promptText("Optional notes (what is this server for?)", "");
+
+  const nextServer = {
+    id: serverId,
+    transport: "stdio" as const,
+    command: parsed.command,
+    args: parsed.args,
+    env: Object.keys(env).length ? env : undefined,
+    notes: notes.trim().length ? notes.trim() : undefined,
+    capabilities: []
+  };
+
+  const nextServers = cfg.servers.filter((s) => s.id !== serverId);
+  nextServers.push(nextServer);
+  nextServers.sort((a, b) => a.id.localeCompare(b.id));
+
+  const nextDoc: McpServersFile = { apiVersion: "mar21/mcp-servers-v1", servers: nextServers };
+  fs.writeFileSync(cfgPath, `${YAML.stringify(nextDoc)}\n`, "utf-8");
+
+  process.stdout.write(`✓ added MCP server: ${serverId}\n`);
+  process.stdout.write(`  file: workspaces/${workspaceId}/_cfg/mcp-servers.yaml\n`);
+  process.stdout.write(`  next: pnpm mar21 mcp doctor --workspace ${workspaceId}\n`);
+  process.stdout.write(`  next: pnpm mar21 mcp tools --workspace ${workspaceId} --server ${serverId}\n`);
+}
+

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -41,6 +41,43 @@ async function promptYesNo(prompt: string, defaultYes = true): Promise<boolean> 
   }
 }
 
+function readTextIfExists(p: string): string | null {
+  try {
+    if (!fs.existsSync(p)) return null;
+    return fs.readFileSync(p, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function summarizeResearchPack(markdown: string, maxLines = 12): string[] {
+  const lines = markdown.split(/\r?\n/);
+  const startIdx = lines.findIndex((l) => l.trim().toLowerCase() === "## findings (stub)" || l.trim().toLowerCase() === "## findings");
+  const from = startIdx === -1 ? 0 : startIdx + 1;
+  const out: string[] = [];
+  for (let i = from; i < lines.length && out.length < maxLines; i += 1) {
+    const l = lines[i] ?? "";
+    if (l.trim().toLowerCase().startsWith("## sources")) break;
+    if (l.trim().length === 0) continue;
+    out.push(l);
+  }
+  return out;
+}
+
+function listNextActionsFromChangeset(wsRoot: string, runId: string): string[] {
+  const p = path.join(wsRoot, "runs", runId, "changeset.yaml");
+  const doc = fs.existsSync(p) ? (readYamlFile(p) as any) : null;
+  const ops = Array.isArray(doc?.ops) ? (doc.ops as any[]) : [];
+  const titles: string[] = [];
+  for (const op of ops) {
+    const operation = typeof op?.operation === "string" ? op.operation : "";
+    if (!operation.endsWith("todo.create") && operation !== "mar21.todo.create") continue;
+    const title = String(op?.params?.task?.title ?? "").trim();
+    if (title) titles.push(title);
+  }
+  return titles;
+}
+
 function extractDriveId(raw: string): { kind: "file" | "folder"; id: string } | null {
   const s = raw.trim();
   if (!s) return null;
@@ -195,28 +232,46 @@ export async function runSession(opts: SessionOptions): Promise<void> {
   });
 
   process.stdout.write(`✓ Research run created: ${researchRun.runId}\n`);
-  process.stdout.write(`  Read it: mar21 show ${researchRun.runId} research_pack --workspace ${workspaceId}\n`);
+  process.stdout.write(`  Read it: pnpm mar21 show ${researchRun.runId} research_pack --workspace ${workspaceId}\n`);
+
+  const rpPath = path.join(wsRoot, "runs", researchRun.runId, "outputs", "research_pack.md");
+  const rp = readTextIfExists(rpPath);
+  if (rp) {
+    const summary = summarizeResearchPack(rp, 10);
+    if (summary.length > 0) {
+      process.stdout.write("\nTop findings (excerpt)\n");
+      for (const l of summary) process.stdout.write(`  ${l}\n`);
+    }
+  }
+
+  const nextActions = listNextActionsFromChangeset(wsRoot, researchRun.runId);
+  if (nextActions.length > 0) {
+    process.stdout.write("\nSuggested next actions\n");
+    for (const t of nextActions.slice(0, 8)) process.stdout.write(`  - ${t}\n`);
+    if (nextActions.length > 8) process.stdout.write(`  (+${nextActions.length - 8} more)\n`);
+  }
 
   const applyNow = canPrompt ? await promptYesNo("Add suggested tasks to your backlog now?", true) : false;
   if (applyNow) {
-    const applied = await applyRunChangeset({ workspace: workspaceId, runId: researchRun.runId });
+    const applied = await applyRunChangeset({ workspace: workspaceId, runId: researchRun.runId, yes: true });
     if (applied.exitCode !== 0) {
       const err = new Error("apply had failures (see logs in the run folder)") as Error & { exitCode?: number };
       err.exitCode = applied.exitCode;
       throw err;
     }
-    process.stdout.write("✓ Backlog updated (todos.yaml)\n");
+    const appliedCount = applied.summary.results.filter((r) => r.status === "applied").length;
+    process.stdout.write(`✓ Backlog updated (${appliedCount} item(s) applied)\n`);
   } else {
-    process.stdout.write(`(Skipped apply) You can apply later: mar21 apply ${researchRun.runId} --workspace ${workspaceId}\n`);
+    process.stdout.write(`(Skipped) Apply later: pnpm mar21 apply ${researchRun.runId} --workspace ${workspaceId}\n`);
   }
 
   const doBrief = canPrompt ? await promptYesNo("Generate a landing page creative brief now?", true) : false;
   if (doBrief) {
     const briefRun = await runPlan("content_brief", { workspace: workspaceId, mode, since: "P0D" });
     process.stdout.write(`✓ Creative brief generated: ${briefRun.runId}\n`);
-    process.stdout.write(`  Show it: mar21 show ${briefRun.runId} creative_brief --workspace ${workspaceId}\n`);
+    process.stdout.write(`  Show it: pnpm mar21 show ${briefRun.runId} creative_brief --workspace ${workspaceId}\n`);
   }
 
   process.stdout.write("\nDone.\n");
-  process.stdout.write(`Next: mar21 show latest todos --workspace ${workspaceId}\n`);
+  process.stdout.write(`Next: pnpm mar21 show latest todos --workspace ${workspaceId}\n`);
 }


### PR DESCRIPTION
Closes #59.

What
- Adds root runner: `pnpm mar21 ...` so marketers don’t type `node packages/cli/dist/index.js`.
- Polishes `mar21 start` output:
  - prints an excerpt of top findings
  - prints suggested next actions from the ChangeSet
  - applies internal low-risk ops with a single confirmation (auto-approve when you say “yes, add tasks”)
- Adds `mar21 mcp add` wizard to register stdio MCP servers in `_cfg/mcp-servers.yaml` (no YAML editing).

Manual test
- `pnpm build`
- `pnpm mar21 start --workspace mar21-self --since P7D`
- `pnpm mar21 show latest research_pack --workspace mar21-self`
- `pnpm mar21 mcp --help` (wizard is interactive)
